### PR TITLE
Add support for returning the type that the completion represents.

### DIFF
--- a/src/Avalonia.Ide.CompletionEngine/Completion.cs
+++ b/src/Avalonia.Ide.CompletionEngine/Completion.cs
@@ -4,24 +4,35 @@ using System.Text;
 
 namespace Avalonia.Ide.CompletionEngine
 {
+    public enum CompletionKind
+    {
+        None,
+        Class,
+        Property,
+        Namespace,
+        Enum
+    }
+
     public class Completion
     {
         public string DisplayText { get; }
         public string InsertText { get; }
         public string Description { get; }
+        public CompletionKind Kind { get; }
         public int? RecommendedCursorOffset { get; }
 
-        public Completion(string displayText, string insertText, string description, int? recommendedCursorOffset = null)
+        public Completion(string displayText, string insertText, string description, CompletionKind kind, int? recommendedCursorOffset = null)
         {
             DisplayText = displayText;
             InsertText = insertText;
             Description = description;
+            Kind = kind;
             RecommendedCursorOffset = recommendedCursorOffset;
         }
 
-        public Completion(string insertText) : this(insertText, insertText, insertText)
+        public Completion(string insertText, CompletionKind kind) : this(insertText, insertText, insertText, kind)
         {
-            
+
         }
     }
 }


### PR DESCRIPTION
Allows contextual icons in intellisense

![image](https://user-images.githubusercontent.com/4672627/34071834-edf17376-e274-11e7-8c79-5daebc3e6138.png)

![image](https://user-images.githubusercontent.com/4672627/34071840-f4b42e56-e274-11e7-844a-60be629818df.png)

![image](https://user-images.githubusercontent.com/4672627/34071845-ff0eccf8-e274-11e7-8268-b887a66087ad.png)
![image](https://user-images.githubusercontent.com/4672627/34071846-0687d178-e275-11e7-9114-979a88364f28.png)
