### PR TITLE
Some improvements to support better xaml completion in avalonia 0.9

### DIFF
--- a/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj
+++ b/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider.csproj
@@ -1,7 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="Exists('$(SolutionDir)Key.snk')">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia.dnlib" Version="2018.11.26-git-67c321d7a4219415492a910d22c95f5efb0c30b8" />

--- a/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
+++ b/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
@@ -61,7 +61,7 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
         public bool IsStatic => _type.IsAbstract && _type.IsSealed;
         public bool IsInterface => _type.IsInterface;
         public bool IsPublic => _type.IsPublic;
-
+        public bool IsGeneric => _type.HasGenericParameters;
         public IEnumerable<string> EnumValues
         {
             get

--- a/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
+++ b/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
@@ -147,6 +147,7 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
         public bool IsPublic => _method.IsPublic;
         public string Name => _method.Name;
         public IList<IParameterInformation> Parameters => _parameters.Value;
+        public string ReturnTypeFullName => _method.ReturnType?.FullName;
         public override string ToString() => Name;
     }
 

--- a/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
+++ b/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
@@ -25,6 +25,8 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
 
         public IEnumerable<string> ManifestResourceNames 
             => _asm.ManifestModule.Resources.Select(r => r.Name.ToString());
+
+        public override string ToString() => Name;
     }
 
     class TypeWrapper : ITypeInformation
@@ -67,6 +69,7 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
                 return _type.Fields.Where(f => f.IsStatic).Select(f => f.Name.String).ToArray();
             }
         }
+        public override string ToString() => Name;
     }
 
     class CustomAttributeWrapper : ICustomAttributeInformation
@@ -124,6 +127,7 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
         public bool HasPublicGetter { get; }
         public string TypeFullName { get; }
         public string Name { get; }
+        public override string ToString() => Name;
     }
 
     class MethodWrapper : IMethodInformation
@@ -143,6 +147,7 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
         public bool IsPublic => _method.IsPublic;
         public string Name => _method.Name;
         public IList<IParameterInformation> Parameters => _parameters.Value;
+        public override string ToString() => Name;
     }
 
     class ParameterWrapper : IParameterInformation

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyInformation.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyInformation.cs
@@ -43,6 +43,7 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
         bool IsPublic { get; }
         string Name { get; }
         IList<IParameterInformation> Parameters { get;}
+        string ReturnTypeFullName { get; }
     }
 
     public interface IParameterInformation

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyInformation.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyInformation.cs
@@ -33,7 +33,7 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
         bool IsStatic { get; }
         bool IsInterface { get; }
         bool IsPublic { get; }
-        //.Fields.Where(f => f.IsStatic).Select(f => f.Name.String).ToArray();
+        bool IsGeneric { get; }
         IEnumerable<string> EnumValues { get; }
     }
 

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
@@ -32,6 +32,7 @@ namespace Avalonia.Ide.CompletionEngine
         public bool IsAvaloniaObjectType { get; set; }
         public MetadataTypeCtorArgument SupportCtorArgument { get; set; }
         public bool IsCompositeValue { get; set; }
+        public bool IsGeneric { get; set; }
     }
 
     public enum MetadataTypeCtorArgument

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
@@ -22,7 +22,11 @@ namespace Avalonia.Ide.CompletionEngine
         public bool IsStatic { get; set; }
         public bool HasHintValues { get; set; }
         public string[] HintValues { get; set; }
-        public Func<string, IEnumerable<string>> CurrentAssemblyHintValuesFunc { get; set; }
+
+        //assembly, type, property
+        public Func<string, MetadataType, MetadataProperty, bool> IsValidForXamlContextFunc { get; set; }
+        //assembly, type, property
+        public Func<string, MetadataType, MetadataProperty, IEnumerable<string>> XamlContextHintValuesFunc { get; set; }
         public string Name { get; set; }
         public string FullName { get; set; } = "";
         public List<MetadataProperty> Properties { get; set; } = new List<MetadataProperty>();
@@ -33,6 +37,7 @@ namespace Avalonia.Ide.CompletionEngine
         public MetadataTypeCtorArgument SupportCtorArgument { get; set; }
         public bool IsCompositeValue { get; set; }
         public bool IsGeneric { get; set; }
+        public bool IsXamlDirective { get; set; }
     }
 
     public enum MetadataTypeCtorArgument

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
@@ -24,6 +24,7 @@ namespace Avalonia.Ide.CompletionEngine
         public string[] HintValues { get; set; }
         public Func<string, IEnumerable<string>> CurrentAssemblyHintValuesFunc { get; set; }
         public string Name { get; set; }
+        public string FullName { get; set; } = "";
         public List<MetadataProperty> Properties { get; set; } = new List<MetadataProperty>();
         public bool HasAttachedProperties { get; set; }
         public bool HasStaticGetProperties { get; set; }

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
@@ -22,6 +22,7 @@ namespace Avalonia.Ide.CompletionEngine
         public bool IsStatic { get; set; }
         public bool HasHintValues { get; set; }
         public string[] HintValues { get; set; }
+        public Func<string, IEnumerable<string>> CurrentAssemblyHintValuesFunc { get; set; }
         public string Name { get; set; }
         public List<MetadataProperty> Properties { get; set; } = new List<MetadataProperty>();
         public bool HasAttachedProperties { get; set; }

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -268,12 +268,6 @@ namespace Avalonia.Ide.CompletionEngine
                     Name = "Key",
                     IsXamlDirective = true
                 },
-                new MetadataType()
-                {
-                    Name = "TypeArguments",
-                    IsXamlDirective = true,
-                    IsValidForXamlContextFunc = (a, t, p) => t?.IsGeneric == true
-                },
             };
 
             //as in avalonia 0.9 Portablexaml is missing we need to hardcode some extensions
@@ -492,6 +486,19 @@ namespace Avalonia.Ide.CompletionEngine
                 uriType.HasHintValues = true;
                 uriType.HintValues = allresourceUrls.ToArray();
                 uriType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(uriType, a);
+            }
+
+            if (types.TryGetValue(typeof(Type).FullName, out MetadataType typeType))
+            {
+                var typeArguments = new MetadataType()
+                {
+                    Name = "TypeArguments",
+                    IsXamlDirective = true,
+                    IsValidForXamlContextFunc = (a, t, p) => t?.IsGeneric == true,
+                    Properties = { new MetadataProperty("", typeType, null, false, false, false, true) }
+                };
+
+                metadata.AddType(Utils.Xaml2006Namespace, typeArguments);
             }
         }
     }

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -36,7 +36,8 @@ namespace Avalonia.Ide.CompletionEngine
                 IsStatic = type.IsStatic,
                 IsMarkupExtension = IsMarkupExtension(type),
                 IsEnum = type.IsEnum,
-                HasHintValues = type.IsEnum
+                HasHintValues = type.IsEnum,
+                IsGeneric = type.IsGeneric,
             };
             if (mt.IsEnum)
                 mt.HintValues = type.EnumValues.ToArray();
@@ -475,6 +476,13 @@ namespace Avalonia.Ide.CompletionEngine
                 uriType.HasHintValues = true;
                 uriType.HintValues = allresourceUrls.ToArray();
                 uriType.CurrentAssemblyHintValuesFunc = a => filterLocalRes(uriType, a);
+            }
+
+            if (types.TryGetValue("System.Type", out MetadataType typeType))
+            {
+                var prop = new MetadataProperty("x:TypeArguments", typeType, null, false, false, false, true);
+                foreach (var t in types.Where(t => t.Value.IsGeneric))                
+                    t.Value.Properties.Add(prop);                
             }
         }
     }

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -274,6 +274,8 @@ namespace Avalonia.Ide.CompletionEngine
             {
                 metadata.AddType(Utils.Xaml2006Namespace, t);
             }
+
+            metadata.AddType(Utils.AvaloniaNamespace, new MetadataType() { Name = "xmlns", HasAttachedProperties = true });
         }
 
         private static void PostProcessTypes(Dictionary<string, MetadataType> types, Metadata metadata, IEnumerable<string> resourceUrls, List<AvaresInfo> avaResValues)

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -256,17 +256,23 @@ namespace Avalonia.Ide.CompletionEngine
                 new MetadataType()
                 {
                     Name = "Class",
-                    HasAttachedProperties = true
+                    IsXamlDirective = true
                 },
                 new MetadataType()
                 {
                     Name = "Name",
-                    HasAttachedProperties = true
+                    IsXamlDirective = true
                 },
                 new MetadataType()
                 {
                     Name = "Key",
-                    HasAttachedProperties = true
+                    IsXamlDirective = true
+                },
+                new MetadataType()
+                {
+                    Name = "TypeArguments",
+                    IsXamlDirective = true,
+                    IsValidForXamlContextFunc = (a, t, p) => t?.IsGeneric == true
                 },
             };
 
@@ -276,7 +282,7 @@ namespace Avalonia.Ide.CompletionEngine
                 metadata.AddType(Utils.Xaml2006Namespace, t);
             }
 
-            metadata.AddType(Utils.AvaloniaNamespace, new MetadataType() { Name = "xmlns", HasAttachedProperties = true });
+            metadata.AddType("", new MetadataType() { Name = "xmlns", IsXamlDirective = true });
         }
 
         private static void PostProcessTypes(Dictionary<string, MetadataType> types, Metadata metadata, IEnumerable<string> resourceUrls, List<AvaresInfo> avaResValues)
@@ -337,9 +343,9 @@ namespace Avalonia.Ide.CompletionEngine
                 }
             }
 
-            resType.CurrentAssemblyHintValuesFunc = a => filterLocalRes(xamlResType, a);
-            xamlResType.CurrentAssemblyHintValuesFunc = a => filterLocalRes(xamlResType, a);
-            styleResType.CurrentAssemblyHintValuesFunc = a => filterLocalRes(styleResType, a);
+            resType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(xamlResType, a);
+            xamlResType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(xamlResType, a);
+            styleResType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(styleResType, a);
 
             types.Add(xamlResType.Name, xamlResType);
 
@@ -455,14 +461,14 @@ namespace Avalonia.Ide.CompletionEngine
             {
                 ibitmapType.HasHintValues = true;
                 ibitmapType.HintValues = allresourceUrls.Where(r => isbitmaptype(r)).ToArray();
-                ibitmapType.CurrentAssemblyHintValuesFunc = a => filterLocalRes(ibitmapType, a);
+                ibitmapType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(ibitmapType, a);
             }
 
             if (types.TryGetValue("Avalonia.Controls.WindowIcon", out MetadataType winIcon))
             {
                 winIcon.HasHintValues = true;
                 winIcon.HintValues = allresourceUrls.Where(r => rhasext(r, ".ico")).ToArray();
-                winIcon.CurrentAssemblyHintValuesFunc = a => filterLocalRes(winIcon, a);
+                winIcon.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(winIcon, a);
             }
 
             if (types.TryGetValue("Avalonia.Markup.Xaml.Styling.StyleInclude", out MetadataType styleIncludeType))
@@ -485,14 +491,7 @@ namespace Avalonia.Ide.CompletionEngine
             {
                 uriType.HasHintValues = true;
                 uriType.HintValues = allresourceUrls.ToArray();
-                uriType.CurrentAssemblyHintValuesFunc = a => filterLocalRes(uriType, a);
-            }
-
-            if (types.TryGetValue("System.Type", out MetadataType typeType))
-            {
-                var prop = new MetadataProperty("x:TypeArguments", typeType, null, false, false, false, true);
-                foreach (var t in types.Where(t => t.Value.IsGeneric))
-                    t.Value.Properties.Add(prop);
+                uriType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(uriType, a);
             }
         }
     }

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -7,14 +7,23 @@ namespace Avalonia.Ide.CompletionEngine
 {
     public static class MetadataConverter
     {
-        internal static bool IsMarkupExtension(ITypeInformation def)
+        internal static bool IsMarkupExtension(ITypeInformation type)
         {
+            var def = type;
+
             while (def != null)
             {
                 if (def.Name == "MarkupExtension")
                     return true;
                 def = def.GetBaseType();
             }
+
+            //in avalonia 0.9 there is no required base class, but convention only
+            if (type.FullName.EndsWith("Extension") && type.Methods.Any(m => m.Name == "ProvideValue"))
+            {
+                return true;
+            }
+
             return false;
         }
 

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -32,6 +32,7 @@ namespace Avalonia.Ide.CompletionEngine
             var mt = new MetadataType
             {
                 Name = type.Name,
+                FullName = type.FullName,
                 IsStatic = type.IsStatic,
                 IsMarkupExtension = IsMarkupExtension(type),
                 IsEnum = type.IsEnum,

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -252,6 +252,21 @@ namespace Avalonia.Ide.CompletionEngine
                     HasSetProperties = true,
                     IsMarkupExtension = true,
                 },
+                new MetadataType()
+                {
+                    Name = "Class",
+                    HasAttachedProperties = true
+                },
+                new MetadataType()
+                {
+                    Name = "Name",
+                    HasAttachedProperties = true
+                },
+                new MetadataType()
+                {
+                    Name = "Key",
+                    HasAttachedProperties = true
+                },
             };
 
             //as in avalonia 0.9 Portablexaml is missing we need to hardcode some extensions

--- a/src/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
+++ b/src/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="Exists('$(SolutionDir)Key.snk')">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)Key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>

--- a/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
+++ b/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
@@ -286,6 +286,19 @@ namespace Avalonia.Ide.CompletionEngine
                                     .Select(v => new Completion(v, CompletionKind.Namespace)));
                         }
                     }
+                    else if (state.AttributeName.EndsWith(":Class"))
+                    {
+
+                        if (_helper.Aliases.TryGetValue(state.AttributeName.Replace(":Class", ""), out var ns) && ns == Utils.Xaml2006Namespace)
+                        {
+                            var asmKey = $";assembly={currentAssemblyName}";
+                            var fullClassNames = _helper.Metadata.Namespaces.Where(v => v.Key.EndsWith(asmKey)).SelectMany(v => v.Value.Values).Select(v => v.FullName);
+                            completions.AddRange(
+                                   fullClassNames
+                                    .Where(v => v.StartsWith(state.AttributeValue))
+                                    .Select(v => new Completion(v, CompletionKind.Class)));
+                        }
+                    }
                 }
             }
 

--- a/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
+++ b/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
@@ -235,13 +235,6 @@ namespace Avalonia.Ide.CompletionEngine
                             .Where(t => t.Value.IsValidForXamlContextFunc?.Invoke(currentAssemblyName, targetType, null) ?? true)
                             .Select(v => new Completion(v.Key, v.Key + "=\"\"", v.Key, CompletionKind.Class, v.Key.Length + 2)));
 
-                    //if (targetType?.IsAvaloniaObjectType == true)
-                    //    completions.AddRange(
-                    //        _helper.FilterTypes(state.AttributeName, true)
-                    //            .Select(v => new Completion(v.Key,
-                    //            v.Key + (v.Value.Properties.Count > 0 ? "." : "=\"\""),
-                    //            v.Key, CompletionKind.Class,
-                    //            v.Value.Properties.Count > 0 ? -1 : v.Key.Length + 2)));
                     if (targetType?.IsAvaloniaObjectType == true)
                         completions.AddRange(
                             _helper.FilterTypeNames(state.AttributeName, withAttachedPropertiesOnly: true)

--- a/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
+++ b/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
@@ -269,6 +269,8 @@ namespace Avalonia.Ide.CompletionEngine
                 }
                 else
                 {
+                    prop = prop ?? _helper.LookupType(state.AttributeName)?.Properties.FirstOrDefault(p => p.Name == "");
+
                     if (prop?.Type?.HasHintValues == true)
                     {
                         var search = text.Substring(state.CurrentValueStart.Value);

--- a/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
+++ b/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
@@ -62,6 +62,18 @@ namespace Avalonia.Ide.CompletionEngine
                     foreach (var type in ns.Values)
                         types[prefix + type.Name] = type;
                 }
+
+                //update alias namespace of x:TypeArguments
+                var genericType = types.Values.FirstOrDefault(t => t.IsGeneric);
+                if (genericType != null)
+                {
+                    var typedArgs = genericType.Properties.FirstOrDefault(p => p.DeclaringType == null && p.Name.EndsWith("TypeArguments"));
+                    var x = aliases.FirstOrDefault(v => v.Value == Utils.Xaml2006Namespace).Key;
+                    if (typedArgs != null && x != null)
+                    {
+                        typedArgs.Name = $"{x}:TypeArguments";
+                    }
+                }
                 _types = types;
 
             }

--- a/src/Avalonia.Ide.CompletionEngine/Utils.cs
+++ b/src/Avalonia.Ide.CompletionEngine/Utils.cs
@@ -45,8 +45,7 @@ namespace Avalonia.Ide.CompletionEngine
         }
 
         public const string AvaloniaNamespace = "https://github.com/avaloniaui";
-
-       
+        public const string Xaml2006Namespace = "http://schemas.microsoft.com/winfx/2006/xaml";
 
         public static TValue GetOrCreate<TKey, TValue>(this Dictionary<TKey, TValue> dic, TKey key,
             Func<TKey, TValue> getter)

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -90,5 +90,11 @@ namespace CompletionEngineTests
         {
             AssertSingleCompletion("<Image Source=\"", "resm:", "resm:CompletionEngineTests.Test.bmp?assembly=CompletionEngineTests");
         }
+
+        [Fact]
+        public void StyleInclude_Source_Uris_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<StyleInclude Source=\"", "avares:", "avares://CompletionEngineTests/Test.xaml");
+        }
     }
 }

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -134,6 +134,18 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void xTypeArguments_Directive_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<local:GenericBaseClass`1 ", "x:T", "x:TypeArguments=\"\"");
+        }
+
+        [Fact]
+        public void xTypeArguments_Directive_Should_Not_Be_Completed_On_NonGeneric_Type()
+        {
+           Assert.Null(GetCompletionsFor("<UserControl x:TypeArgum"));
+        }
+
+        [Fact]
         public void xmlns_Directive_Should_Be_Completed()
         {
             var compl = GetCompletionsFor("<UserControl x").Completions;

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -134,6 +134,14 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void xmlns_Directive_Should_Be_Completed()
+        {
+            var compl = GetCompletionsFor("<UserControl x").Completions;
+
+            Assert.Contains(compl, v => v.InsertText == "xmlns=\"\"");
+        }
+
+        [Fact]
         public void xClass_Value_Should_Be_Completed()
         {
             AssertSingleCompletion("<UserControl x:Class=\"", "", "CompletionEngineTests.TestUserControl");

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -140,6 +140,12 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void xTypeArguments_Value_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<local:GenericBaseClass`1 x:TypeArguments=\"", "Tex", "TextBlock");
+        }
+
+        [Fact]
         public void xTypeArguments_Directive_Should_Not_Be_Completed_On_NonGeneric_Type()
         {
            Assert.Null(GetCompletionsFor("<UserControl x:TypeArgum"));

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -108,5 +108,11 @@ namespace CompletionEngineTests
         {
             AssertSingleCompletion("<StyleInclude Source=\"", "/", "/Test.xaml");
         }
+
+        [Fact]
+        public void xClass_Value_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<UserControl x:Class=\"", "", "CompletionEngineTests.TestUserControl");
+        }
     }
 }

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -92,9 +92,21 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void Image_Source_RelativeUris_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<Image Source=\"", "resm:", "resm:CompletionEngineTests.Test.bmp");
+        }
+
+        [Fact]
         public void StyleInclude_Source_Uris_Should_Be_Completed()
         {
             AssertSingleCompletion("<StyleInclude Source=\"", "avares:", "avares://CompletionEngineTests/Test.xaml");
+        }
+
+        [Fact]
+        public void StyleInclude_Source_RelativeUris_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<StyleInclude Source=\"", "/", "/Test.xaml");
         }
     }
 }

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -67,7 +67,7 @@ namespace CompletionEngineTests
         [Fact]
         public void StyleSelector_Some_WellKnown_Keywords_Should_Be_Completed()
         {
-            var compl =  GetCompletionsFor("<Style Selector=\"").Completions;
+            var compl = GetCompletionsFor("<Style Selector=\"").Completions;
 
             Assert.Contains(compl, v => v.InsertText == ">");
             Assert.Contains(compl, v => v.InsertText == ".");
@@ -107,6 +107,30 @@ namespace CompletionEngineTests
         public void StyleInclude_Source_RelativeUris_Should_Be_Completed()
         {
             AssertSingleCompletion("<StyleInclude Source=\"", "/", "/Test.xaml");
+        }
+
+        [Fact]
+        public void xClass_Directive_Should_Be_Completed()
+        {
+            var compl = GetCompletionsFor("<UserControl x:Cla").Completions;
+
+            Assert.Contains(compl, v => v.InsertText == "x:Class=\"\"");
+        }
+
+        [Fact]
+        public void xName_Directive_Should_Be_Completed()
+        {
+            var compl = GetCompletionsFor("<UserControl x:N").Completions;
+
+            Assert.Contains(compl, v => v.InsertText == "x:Name=\"\"");
+        }
+
+        [Fact]
+        public void xKey_Directive_Should_Be_Completed()
+        {
+            var compl = GetCompletionsFor("<UserControl x:K").Completions;
+
+            Assert.Contains(compl, v => v.InsertText == "x:Key=\"\"");
         }
 
         [Fact]

--- a/tests/CompletionEngineTests/CompletionEngineTests.csproj
+++ b/tests/CompletionEngineTests/CompletionEngineTests.csproj
@@ -2,13 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
-
-    <ItemGroup>
-      <None Remove="Test.bmp" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
@@ -20,6 +15,7 @@
 
     <ItemGroup>
       <EmbeddedResource Include="Test.bmp" />
+      <AvaloniaResource Include="Test.xaml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/CompletionEngineTests/CompletionEngineTests.csproj
+++ b/tests/CompletionEngineTests/CompletionEngineTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
         <PackageReference Include="xunit" Version="2.3.1" />
-        <PackageReference Include="Avalonia" Version="0.7.0" />
+        <PackageReference Include="Avalonia" Version="0.9.0-preview2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>

--- a/tests/CompletionEngineTests/Test.xaml
+++ b/tests/CompletionEngineTests/Test.xaml
@@ -1,0 +1,5 @@
+﻿<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style Selector="TextBlock">
+        
+    </Style>
+</Styles>

--- a/tests/CompletionEngineTests/TestUserControl.cs
+++ b/tests/CompletionEngineTests/TestUserControl.cs
@@ -1,0 +1,13 @@
+﻿using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace CompletionEngineTests
+{
+    public class TestUserControl : UserControl
+    {
+        public TestUserControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/tests/CompletionEngineTests/XamlCompletionTestBase.cs
+++ b/tests/CompletionEngineTests/XamlCompletionTestBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using Avalonia.Ide.CompletionEngine;
 using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 using Avalonia.Ide.CompletionEngine.DnlibMetadataProvider;
@@ -34,7 +35,7 @@ namespace CompletionEngineTests
         {
             xaml = Prologue + xaml;
             var engine = new CompletionEngine();
-            var set = engine.GetCompletions(Metadata, xaml, xaml.Length);
+            var set = engine.GetCompletions(Metadata, xaml, xaml.Length, Assembly.GetCallingAssembly().GetName().Name);
             return TransformCompletionSet(set);
         }
 


### PR DESCRIPTION
- support x:Class directive
- support x:Name directive
- support x:TypeArguments directive
- support avares:// for xaml compiled resources
- support local completions without assembly name for avares:// and resm:
- Unit tests for all the new features added in this pr