### PR TITLE
Allow renaming of attributes without adding ="" if it is already present

### DIFF
--- a/tests/CompletionEngineTests/BasicTests.cs
+++ b/tests/CompletionEngineTests/BasicTests.cs
@@ -12,6 +12,12 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void Property_Should_Be_Renamed()
+        {
+            AssertSingleCompletionInMiddleOfText("<UserControl ", "=\"Top\"","HorizontalAlign", "HorizontalAlignment");
+        }
+
+        [Fact]
         public void Property_Should_Be_Completed()
         {
             AssertSingleCompletion("<UserControl ", "HorizontalAlign", "HorizontalAlignment=\"\"");
@@ -54,6 +60,12 @@ namespace CompletionEngineTests
         public void AttachedProperty_Should_Be_Completed()
         {
             AssertSingleCompletion("<UserControl Grid.", "Ro", "Row=\"\"");
+        }
+
+        [Fact]
+        public void AttachedProperty_Should_Be_Renamed()
+        {
+            AssertSingleCompletionInMiddleOfText("<UserControl Grid.", "=\"2\"", "Ro", "Row");
         }
 
         [Fact]

--- a/tests/CompletionEngineTests/XamlCompletionTestBase.cs
+++ b/tests/CompletionEngineTests/XamlCompletionTestBase.cs
@@ -31,17 +31,17 @@ namespace CompletionEngineTests
             };
         }
 
-        protected CompletionSet GetCompletionsFor(string xaml)
+        protected CompletionSet GetCompletionsFor(string xaml, string xamlAfterCursor ="")
         {
             xaml = Prologue + xaml;
             var engine = new CompletionEngine();
-            var set = engine.GetCompletions(Metadata, xaml, xaml.Length, Assembly.GetCallingAssembly().GetName().Name);
+            var set = engine.GetCompletions(Metadata, xaml + xamlAfterCursor, xaml.Length, Assembly.GetCallingAssembly().GetName().Name);
             return TransformCompletionSet(set);
         }
 
-        protected void AssertSingleCompletion(string xaml, string typed, string completion)
+        protected void AssertSingleCompletionInMiddleOfText(string xaml, string xamlAfterCursor, string typed, string completion)
         {
-            var comp = GetCompletionsFor(xaml + typed);
+            var comp = GetCompletionsFor(xaml + typed, xamlAfterCursor);
             if (comp == null)
                 throw new Exception("No completions found");
 
@@ -50,6 +50,12 @@ namespace CompletionEngineTests
             Assert.Contains(comp.Completions, c => c.InsertText == completion);
 
             Assert.Single(comp.Completions, c => c.InsertText == completion);
+
+        }
+
+        protected void AssertSingleCompletion(string xaml, string typed, string completion)
+        {
+            AssertSingleCompletionInMiddleOfText(xaml, "", typed, completion);
         }
     }
 }


### PR DESCRIPTION
Currently if we are editing attribute IDE will always insert ="" after completing attribute. This is really irritating, especially when we are changing Grid.Column="1" to Grid.Row="1" and so on.

In this PR i have added option to pass whole file to CompletionEngine (fullText parameter to GetCompletions). Then engine can check if next character is = and fill just property name.

For this to work we also need to pass full file text to CompletionEngine, see this [branch](https://github.com/ShadowDancer/AvaloniaVS/commits/fix/allow_renaming_attributes).