### PR TITLE
Add text manipulation capabilities

### DIFF
--- a/src/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
+++ b/src/Avalonia.Ide.CompletionEngine/Avalonia.Ide.CompletionEngine.csproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.Ide.CompletionEngine/CloseXmlTagManipulation.cs
+++ b/src/Avalonia.Ide.CompletionEngine/CloseXmlTagManipulation.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Avalonia.Ide.CompletionEngine
+{
+    public class CloseXmlTagManipulation
+    {
+        private readonly XmlParser _state;
+        private readonly ReadOnlyMemory<char> _text;
+        private readonly int _position;
+
+        public CloseXmlTagManipulation(XmlParser state, ReadOnlyMemory<char> text, int position)
+        {
+            _state = state;
+            _text = text;
+            _position = position;
+        }
+
+        public void TryCloseTag(ITextChange textChange, IList<TextManipulation> manipulations)
+        {
+            var currentTag = _state.ParseCurrentTagName();
+            if (textChange.NewText == "/" && !string.IsNullOrEmpty(currentTag) && currentTag != "/")
+            {
+                var text = _text.Span;
+                int pos = _state.ParserPos;
+                char c = ' ';
+                while (char.IsWhiteSpace(c) && text.Length > pos + 1)
+                {
+                    pos++;
+                    c = text[pos];
+                }
+
+                bool tagAlreadyClosed = c == '>';
+                if (!tagAlreadyClosed)
+                {
+                    manipulations.Add(TextManipulation.Insert(_position + 1, $">"));
+                }
+                else
+                {
+                    var closingTagPos = FindClosingTag(currentTag, pos + 1);
+                    if(closingTagPos != null)
+                    {
+                        manipulations.Add(TextManipulation.Insert(_position + 1, $">"));
+                        manipulations.Add(TextManipulation.Delete(_position + 1, closingTagPos.Value - _position));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// If we just changed open tag to self-closing this finds closing tag if closed tag was empty
+        /// </summary>
+        /// <returns>Position of closing brace of closing tag if this tag is empty and self closing</returns>
+        private int? FindClosingTag(string currentTag, int startPos)
+        {
+            int pos = startPos;
+
+            var text = _text.Span;
+            if (pos >= text.Length)
+            {
+                return null;
+            }
+
+            // skip eventual whitespaces
+
+            char c = text[pos];
+            SkipWhitespace(ref pos, text, ref c);
+
+            // Check next text is </closingTag>
+            if (text.Length < pos + currentTag.Length + 3
+                || text[pos] != '<'
+                || text[pos + 1] != '/')
+            {
+                return null;
+            }
+
+            pos = pos + 2;
+            for (int i = 0; i < currentTag.Length; i++)
+            {
+                if (text[pos] != currentTag[i])
+                {
+                    return null;
+                }
+                pos++;
+            }
+
+            // parse whitespace
+            SkipWhitespace(ref pos, text, ref c);
+
+            if(text.Length <= pos || text[pos] != '>')
+            {
+                return null;
+            }
+
+            return pos;
+        }
+
+        private static void SkipWhitespace(ref int pos, ReadOnlySpan<char> text, ref char c)
+        {
+            for (; char.IsWhiteSpace(c) && text.Length > pos + 1; pos++)
+            {
+                c = text[pos];
+            }
+        }
+    }
+}

--- a/src/Avalonia.Ide.CompletionEngine/ITextChange.cs
+++ b/src/Avalonia.Ide.CompletionEngine/ITextChange.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Avalonia.Ide.CompletionEngine
+{
+    public interface ITextChange
+    {
+        int NewPosition { get; }
+        string NewText { get; }
+    }
+}

--- a/src/Avalonia.Ide.CompletionEngine/ITextChange.cs
+++ b/src/Avalonia.Ide.CompletionEngine/ITextChange.cs
@@ -1,12 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 
 namespace Avalonia.Ide.CompletionEngine
 {
+    /// <summary>
+    /// Abstracts text change from editor
+    /// </summary>
     public interface ITextChange
     {
+        /// <summary>
+        /// Position of new text
+        /// </summary>
         int NewPosition { get; }
+
+        /// <summary>
+        /// Text that replaced old text
+        /// </summary>
         string NewText { get; }
+
+        /// <summary>
+        /// Position of replaced text
+        /// </summary>
+        int OldPosition { get; }
+
+        /// <summary>
+        /// Text that was replaced
+        /// </summary>
+        string OldText { get; }
     }
 }

--- a/src/Avalonia.Ide.CompletionEngine/ITextChangeExtensions.cs
+++ b/src/Avalonia.Ide.CompletionEngine/ITextChangeExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Avalonia.Ide.CompletionEngine
+{
+    public static class ITextChangeExtensions
+    {
+        public static IEnumerable<TextManipulation> AsManipulations(this ITextChange textChange, int offset = 0)
+        {
+            if (!string.IsNullOrEmpty(textChange.OldText))
+            {
+                yield return TextManipulation.Delete(textChange.OldPosition + offset + 1, textChange.OldText.Length);
+            }
+
+            if (!string.IsNullOrEmpty(textChange.NewText))
+            {
+                yield return TextManipulation.Insert(textChange.NewPosition + offset + 1, textChange.NewText);
+            }
+        }
+
+        /// <summary>
+        /// TextChange reversal is required to compare original text (before change)
+        /// </summary>
+        /// <param name="textChangeOffset">
+        /// As text change is scoped in document this param allows to apply it to short strings, ie. tag names
+        /// </param>
+        public static string ReverseOn(this ITextChange textChange, string input, int textChangeOffset = 0)
+        {
+            if (!string.IsNullOrEmpty(textChange.NewText))
+            {
+                var start = textChange.NewPosition - textChangeOffset;
+                input = input.Remove(start, Math.Min(input.Length - start,textChange.NewText.Length));
+            }
+            if (!string.IsNullOrEmpty(textChange.OldText))
+            {
+                input = input.Insert(textChange.OldPosition - textChangeOffset, textChange.OldText);
+            }
+            return input;
+        }
+    }
+}

--- a/src/Avalonia.Ide.CompletionEngine/ManipulationResult.cs
+++ b/src/Avalonia.Ide.CompletionEngine/ManipulationResult.cs
@@ -1,9 +1,0 @@
-﻿using System.Collections.Generic;
-
-namespace Avalonia.Ide.CompletionEngine
-{
-    public class ManipulationResult
-    {
-        public IList<TextManipulation> Maniplations { get; set; } = new List<TextManipulation>();
-    }
-}

--- a/src/Avalonia.Ide.CompletionEngine/ManipulationResult.cs
+++ b/src/Avalonia.Ide.CompletionEngine/ManipulationResult.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Avalonia.Ide.CompletionEngine
+{
+    public class ManipulationResult
+    {
+        public IList<TextManipulation> Maniplations { get; set; } = new List<TextManipulation>();
+    }
+}

--- a/src/Avalonia.Ide.CompletionEngine/ManipulationType.cs
+++ b/src/Avalonia.Ide.CompletionEngine/ManipulationType.cs
@@ -1,0 +1,8 @@
+﻿namespace Avalonia.Ide.CompletionEngine
+{
+    public enum ManipulationType
+    {
+        Insert,
+        Delete
+    }
+}

--- a/src/Avalonia.Ide.CompletionEngine/TextManipulation.cs
+++ b/src/Avalonia.Ide.CompletionEngine/TextManipulation.cs
@@ -1,0 +1,30 @@
+﻿namespace Avalonia.Ide.CompletionEngine
+{
+    public class TextManipulation
+    {
+        public static TextManipulation Insert(int postition, string text)
+        {
+            return new TextManipulation(postition, postition + text.Length, text, ManipulationType.Insert);
+        }
+        public static TextManipulation Delete(int postition, int length)
+        {
+            return new TextManipulation(postition, postition + length, null, ManipulationType.Delete);
+        }
+
+        private TextManipulation(int start, int end, string text, ManipulationType type)
+        {
+            Start = start;
+            End = end;
+            Text = text;
+            Type = type;
+        }
+
+        public int Start { get; }
+
+        public int End { get; }
+
+        public string Text { get; }
+
+        public ManipulationType Type { get; }
+    }
+}

--- a/src/Avalonia.Ide.CompletionEngine/TextManipulation.cs
+++ b/src/Avalonia.Ide.CompletionEngine/TextManipulation.cs
@@ -1,5 +1,9 @@
 ﻿namespace Avalonia.Ide.CompletionEngine
 {
+    /// <summary>
+    /// Represents edit to be applied to textbuffer
+    /// For simplicity sake two types of manipulations are offered only - Insertion and Deletion
+    /// </summary>
     public class TextManipulation
     {
         public static TextManipulation Insert(int postition, string text)

--- a/src/Avalonia.Ide.CompletionEngine/TextManipulator.cs
+++ b/src/Avalonia.Ide.CompletionEngine/TextManipulator.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Avalonia.Ide.CompletionEngine
 {
@@ -68,7 +70,7 @@ namespace Avalonia.Ide.CompletionEngine
             || _state.State == XmlParser.ParserState.InsideElement)
             {
 
-                TryCloseTag(textChange, maniplations);
+                new CloseXmlTagManipulation(_state, _text, _position).TryCloseTag(textChange, maniplations);
             }
 
             return maniplations.OrderByDescending(n => n.Start).ToList();
@@ -128,41 +130,6 @@ namespace Avalonia.Ide.CompletionEngine
             }
         }
 
-        private void TryCloseTag(ITextChange textChange, IList<TextManipulation> manipulations)
-        {
-            var currentTag = _state.ParseCurrentTagName();
-            if (textChange.NewText == "/" && !string.IsNullOrEmpty(currentTag) && currentTag != "/")
-            {
-                if (IsTagAlreadyClosed())
-                {
-                    return;
-                }
-
-                manipulations.Add(TextManipulation.Insert(_position + 1, $">"));
-            }
-        }
-
-        private bool IsTagAlreadyClosed()
-        {
-            if (_text.Length > _position + 1)
-            {
-                var remainingSpan = _text.Span;
-                // at i == 0 we have "/"
-                for (int i = _position + 1; i < _text.Length; i++)
-                {
-                    var nextChar = remainingSpan[i];
-                    if (!char.IsWhiteSpace(nextChar))
-                    {
-                        if (nextChar == '>')
-                        {
-                            return true;
-                        }
-                        break;
-                    }
-                }
-            }
-
-            return false;
-        }
+        
     }
 }

--- a/src/Avalonia.Ide.CompletionEngine/TextManipulator.cs
+++ b/src/Avalonia.Ide.CompletionEngine/TextManipulator.cs
@@ -76,7 +76,7 @@ namespace Avalonia.Ide.CompletionEngine
 
         private void SynchronizeStartAndEndTag(ITextChange textChange, List<TextManipulation> maniplations)
         {
-            string startTag = _state.TagName;
+            string startTag = _state.ParseCurrentTagName();
             int? maybeTagStart = _state.CurrentValueStart;
             if(maybeTagStart == null)
             {
@@ -96,7 +96,7 @@ namespace Avalonia.Ide.CompletionEngine
             XmlParser searchEndTag = _state.Clone();
             if (searchEndTag.SeekClosingTag())
             {
-                string endTag = searchEndTag.TagName;
+                string endTag = searchEndTag.ParseCurrentTagName();
                 if(endTag[0] != '/')
                 {
                     return;
@@ -123,7 +123,7 @@ namespace Avalonia.Ide.CompletionEngine
 
         private void TryCloseTag(ITextChange textChange, IList<TextManipulation> manipulations)
         {
-            if(textChange.NewText == "/" && !string.IsNullOrEmpty(_state.TagName))
+            if(textChange.NewText == "/" && !string.IsNullOrEmpty(_state.ParseCurrentTagName()))
             {
                 if (IsTagAlreadyClosed())
                 {

--- a/src/Avalonia.Ide.CompletionEngine/TextManipulator.cs
+++ b/src/Avalonia.Ide.CompletionEngine/TextManipulator.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Avalonia.Ide.CompletionEngine
+{
+    /// <summary>
+    /// Allows IDE to manipulate text typed by user, without completion session
+    /// I.E. close xml tags, rename end tag, itp.
+    /// </summary>
+    public class TextManipulator
+    {
+        private readonly Metadata _completionMetadata;
+        private readonly string _text;
+        private readonly int _position;
+        private readonly XmlParser _state;
+        private readonly int _parserOffset = 0;
+        private ReadOnlyMemory<char> _remainingText;
+
+        public TextManipulator(Metadata completionMetadata, string text, int position)
+        {
+            _completionMetadata = completionMetadata;
+            _text = text;
+            _position = position;
+
+            
+            var fullText = text.AsMemory();
+            var textToParse = fullText;
+
+            // To improve performance parse only last tag
+            if(text.Length > 0)
+            {
+                var parserStart = position;
+                if (parserStart >= text.Length)
+                {
+                    parserStart = text.Length - 1;
+                }
+                parserStart = text.LastIndexOf('<', parserStart);
+                if(parserStart < 0)
+                {
+                    parserStart = 0;
+                }
+
+                int parserEnd;
+                if(text.Length > position)
+                {
+                    parserEnd = position;
+                }
+                else
+                {
+                    parserEnd = position - 1;
+                }
+
+                _parserOffset = parserStart;
+                textToParse = textToParse.Slice(parserStart, parserEnd - parserStart);
+
+                _remainingText = fullText.Slice(parserEnd);
+            }
+            
+
+            _state = XmlParser.Parse(textToParse);
+        }
+
+        public IList<TextManipulation> ManipulateText(ITextChange textChange)
+        {
+            IList<TextManipulation> maniplations = new List<TextManipulation>();
+            switch (_state.State)
+            {
+                case XmlParser.ParserState.StartElement:
+                case XmlParser.ParserState.AfterAttributeValue:
+                case XmlParser.ParserState.InsideElement:
+                    TryCloseTag(textChange, maniplations);
+                    break;
+            
+            }
+
+            return maniplations.OrderByDescending(n => n.Start).ToList();
+        }
+
+        private void TryCloseTag(ITextChange textChange, IList<TextManipulation> manipulations)
+        {
+            if(textChange.NewText == "/" && !string.IsNullOrEmpty(_state.TagName))
+            {
+                if (IsTagAlreadyClosed())
+                {
+                    return;
+                }
+
+                manipulations.Add(TextManipulation.Insert(_position + 1, $">"));
+            }
+        }
+
+        private bool IsTagAlreadyClosed()
+        {
+            if (_remainingText.Length > 1)
+            {
+                var remainingSpan = _remainingText.Span;
+                for (int i = 1; i < _remainingText.Length; i++)
+                {
+                    var nextChar = remainingSpan[i];
+                    if (!char.IsWhiteSpace(nextChar))
+                    {
+                        if (nextChar == '>')
+                        {
+                            return true;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
+++ b/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
@@ -136,8 +136,6 @@ namespace Avalonia.Ide.CompletionEngine
                     {
                         _containingTagStart.Pop();
                     }
-
-
                 }
                 else if ((State == ParserState.InsideElement
                     || State == ParserState.StartElement
@@ -145,7 +143,10 @@ namespace Avalonia.Ide.CompletionEngine
                         && c == '>' && CheckPrev(i - 1, "/"))
                 {
                     State = ParserState.None;
-                    _containingTagStart.Pop();
+                    if(_containingTagStart.Count > 0)
+                    {
+                        _containingTagStart.Pop();
+                    }
                 }
                 else if ((State == ParserState.InsideElement 
                     || State == ParserState.StartElement 

--- a/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
+++ b/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
@@ -7,9 +7,6 @@ namespace Avalonia.Ide.CompletionEngine
 {
     public class XmlParser
     {
-        private readonly ReadOnlyMemory<char> _data;
-        private int _parserPos;
-
         public enum ParserState
         {
             None,
@@ -25,6 +22,8 @@ namespace Avalonia.Ide.CompletionEngine
 
         public ParserState State { get; set; }
 
+        private readonly ReadOnlyMemory<char> _data;
+        private int _parserPos;
         private int _elementNameStart;
         private int _attributeNameStart;
         private int? _elementNameEnd;
@@ -308,7 +307,10 @@ namespace Avalonia.Ide.CompletionEngine
         /// <returns></returns>
         public XmlParser Clone()
         {
-            return (XmlParser)MemberwiseClone();
+            var newParser = (XmlParser)MemberwiseClone();
+            var clonedStack = = new Stack<int>(new Stack<int>(_containingTagStart));
+            newParser._containingTagStart = clonedStack;
+            return newParser;
         }
     }
 }

--- a/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
+++ b/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
@@ -214,27 +214,28 @@ namespace Avalonia.Ide.CompletionEngine
                 return "";
             }
 
-            var endTag = _elementNameStart;
-            if (_elementNameEnd== null)
+            if (_elementNameEnd != null)
             {
-                for (int i = _elementNameStart; i < span.Length; i++)
-                {
-                    char c = span[i];
-                    bool isClosingTag = i == _elementNameStart && c == '/';
-                    if (!isClosingTag)
-                    {
-                        if (char.IsWhiteSpace(c) || c == '/' || c == '>')
-                        {
-                            endTag = i;
-                            break;
-                        }
-                    }
-
-                    endTag = i + 1;
-                }
+                return span.Slice(_elementNameStart, _elementNameEnd.Value - _elementNameStart + 1).ToString();
             }
-            return span.Slice(_elementNameStart, endTag - _elementNameStart).ToString();
 
+            var endTag = _elementNameEnd;
+            for (int i = _elementNameStart; i < span.Length; i++)
+            {
+                char c = span[i];
+                bool isClosingTag = i == _elementNameStart && c == '/';
+                if (!isClosingTag)
+                {
+                    if (char.IsWhiteSpace(c) || c == '/' || c == '>')
+                    {
+                        endTag = i;
+                        break;
+                    }
+                }
+
+                endTag = i + 1;
+            }
+            return span.Slice(_elementNameStart, endTag.Value - _elementNameStart).ToString();
         }
 
         public static XmlParser Parse(string data)

--- a/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
+++ b/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
@@ -8,7 +8,8 @@ namespace Avalonia.Ide.CompletionEngine
     public class XmlParser
     {
         private readonly ReadOnlyMemory<char> _data;
-        
+        private int _parserPos;
+
         public enum ParserState
         {
             None,
@@ -30,10 +31,45 @@ namespace Avalonia.Ide.CompletionEngine
         private int? _attributeNameEnd;
         private int _attributeValueStart;
         private Stack<int> _containingTagStart;
+        private bool _isClosingTag;
 
-        public string TagName => State >= ParserState.StartElement
-            ? _data.Span.Slice(_elementNameStart, (_elementNameEnd ?? (_data.Length - 1)) - _elementNameStart + 1).ToString()
-            : null;
+        public string TagName
+        {
+            get
+            {
+                if (State < ParserState.StartElement)
+                {
+                    return null;
+                }
+                var span = _data.Span;
+                if(_elementNameStart >= span.Length)
+                {
+                    return "";
+                }
+
+                if (_elementNameEnd == null)
+                {
+                    // Check where is element end
+                    _elementNameEnd = _elementNameStart;
+                    for (int i = _elementNameStart; i < span.Length; i++)
+                    {
+                        char c = span[i];
+                        bool isClosingTag = i == _elementNameStart && c == '/';
+                        if (!isClosingTag)
+                        {
+                            if (char.IsWhiteSpace(c) || c == '/' || c == '>')
+                            {
+                                _elementNameEnd = i;
+                                break;
+                            }
+                        }
+
+                        _elementNameEnd = i+1;
+                    }
+                }
+                return span.Slice(_elementNameStart, _elementNameEnd.Value - _elementNameStart).ToString();
+            }
+        }
 
         public string AttributeName => State >= ParserState.StartAttribute
             ? _data.Span.Slice(_attributeNameStart, (_attributeNameEnd ?? (_data.Length - 1)) - _attributeNameStart + 1).ToString()
@@ -57,16 +93,16 @@ namespace Avalonia.Ide.CompletionEngine
 
         public int NestingLevel => _containingTagStart.Count;
 
-        XmlParser(ReadOnlyMemory<char> data)
+        public int ParserPos => _parserPos;
+
+        public bool IsInClosingTag => _isClosingTag;
+
+        public XmlParser(ReadOnlyMemory<char> data, int start = 0)
         {
-            _data = data;
             _containingTagStart = new Stack<int>();
+            _data = data;
+            _parserPos = start;
         }
-        XmlParser(string data) : this(data.AsMemory())
-        {
-
-        }
-
 
         private const string CommentStart = "!--";
         private const string CommentEnd = "-->";
@@ -88,100 +124,106 @@ namespace Avalonia.Ide.CompletionEngine
             return true;
         }
 
-        void Parse()
+        private bool ParseChar()
         {
-            for (var i = 0; i < _data.Length; i++)
+            if(_parserPos >= _data.Length)
             {
-                var c = _data.Span[i];
-                if (c == '<' && State == ParserState.None)
-                {
-                    State = ParserState.StartElement;
-                    _elementNameStart = i + 1;
-                    _elementNameEnd = null;
+                return false;
+            }
 
-                    _containingTagStart.Push(i);
-                }
-                else if (State == ParserState.StartElement && CheckPrev(i, CommentStart))
+            int i = _parserPos++;
+            var span = _data.Span;
+            var c = span[i];
+            if (c == '<' && State == ParserState.None)
+            {
+                State = ParserState.StartElement;
+                _isClosingTag = _data.Span.Length > i + 1 && span[i + 1] == '/';
+                _elementNameStart = i + 1;
+                _elementNameEnd = null;
+
+                _containingTagStart.Push(i);
+            }
+            else if (State == ParserState.StartElement && CheckPrev(i, CommentStart))
+            {
+                State = ParserState.InsideComment;
+            }
+            else if (State == ParserState.InsideComment && CheckPrev(i, CommentEnd))
+            {
+                State = ParserState.None;
+            }
+            else if (State == ParserState.StartElement && CheckPrev(i, CdataStart))
+            {
+                State = ParserState.InsideCdata;
+            }
+            else if (State == ParserState.InsideCdata && CheckPrev(i, CdataEnd))
+            {
+                State = ParserState.None;
+            }
+            else if (State == ParserState.StartElement && char.IsWhiteSpace(c))
+            {
+                State = ParserState.InsideElement;
+                _attributeNameStart = i;
+                _elementNameEnd = i - 1;
+            }
+            else if ((State == ParserState.InsideElement
+               || State == ParserState.StartElement
+               || State == ParserState.AfterAttributeValue)
+                   && c == '/' && CheckPrev(i - 1, "<"))
+            {
+                if (_containingTagStart.Count > 0)
                 {
-                    State = ParserState.InsideComment;
+                    _containingTagStart.Pop();
                 }
-                else if (State == ParserState.InsideComment && CheckPrev(i, CommentEnd))
+                if (_containingTagStart.Count > 0)
                 {
-                    State = ParserState.None;
-                }
-                else if (State == ParserState.StartElement && CheckPrev(i, CdataStart))
-                {
-                    State = ParserState.InsideCdata;
-                }
-                else if (State == ParserState.InsideCdata && CheckPrev(i, CdataEnd))
-                {
-                    State = ParserState.None;
-                }
-                else if (State == ParserState.StartElement && char.IsWhiteSpace(c))
-                {
-                    State = ParserState.InsideElement;
-                    _attributeNameStart = i;
-                    _elementNameEnd = i - 1;
-                }
-                else if ((State == ParserState.InsideElement
-                   || State == ParserState.StartElement
-                   || State == ParserState.AfterAttributeValue)
-                       && c == '/' && CheckPrev(i - 1, "<"))
-                {
-                    if(_containingTagStart.Count > 0)
-                    {
-                        _containingTagStart.Pop();
-                    }
-                    if (_containingTagStart.Count > 0)
-                    {
-                        _containingTagStart.Pop();
-                    }
-                }
-                else if ((State == ParserState.InsideElement
-                    || State == ParserState.StartElement
-                    || State == ParserState.AfterAttributeValue)
-                        && c == '>' && CheckPrev(i - 1, "/"))
-                {
-                    State = ParserState.None;
-                    if(_containingTagStart.Count > 0)
-                    {
-                        _containingTagStart.Pop();
-                    }
-                }
-                else if ((State == ParserState.InsideElement 
-                    || State == ParserState.StartElement 
-                    || State == ParserState.AfterAttributeValue) 
-                        && c == '>')
-                {
-                    State = ParserState.None;
-                }
-                else if (State == ParserState.InsideElement && (char.IsLetter(c) || c=='_' || c==':'))
-                {
-                    State = ParserState.StartAttribute;
-                    _attributeNameStart = i;
-                    _attributeNameEnd = null;
-                }
-                else if (State == ParserState.StartAttribute && (c == '=' || char.IsWhiteSpace(c)))
-                {
-                    State = ParserState.BeforeAttributeValue;
-                    _attributeNameEnd = i - 1;
-                }
-                else if (State == ParserState.BeforeAttributeValue && c == '"')
-                {
-                    State = ParserState.AttributeValue;
-                    _attributeValueStart = i + 1;
-                }
-                else if (State == ParserState.AttributeValue && c == '"')
-                {
-                    State = ParserState.AfterAttributeValue;
-                }
-                else if (State == ParserState.AfterAttributeValue)
-                {
-                    State = ParserState.InsideElement;
+                    _containingTagStart.Pop();
                 }
             }
+            else if ((State == ParserState.InsideElement
+                || State == ParserState.StartElement
+                || State == ParserState.AfterAttributeValue)
+                    && c == '>' && CheckPrev(i - 1, "/"))
+            {
+                State = ParserState.None;
+                if (_containingTagStart.Count > 0)
+                {
+                    _containingTagStart.Pop();
+                }
+            }
+            else if ((State == ParserState.InsideElement
+                || State == ParserState.StartElement
+                || State == ParserState.AfterAttributeValue)
+                    && c == '>')
+            {
+                State = ParserState.None;
+            }
+            else if (State == ParserState.InsideElement && (char.IsLetter(c) || c == '_' || c == ':'))
+            {
+                State = ParserState.StartAttribute;
+                _attributeNameStart = i;
+                _attributeNameEnd = null;
+            }
+            else if (State == ParserState.StartAttribute && (c == '=' || char.IsWhiteSpace(c)))
+            {
+                State = ParserState.BeforeAttributeValue;
+                _attributeNameEnd = i - 1;
+            }
+            else if (State == ParserState.BeforeAttributeValue && c == '"')
+            {
+                State = ParserState.AttributeValue;
+                _attributeValueStart = i + 1;
+            }
+            else if (State == ParserState.AttributeValue && c == '"')
+            {
+                State = ParserState.AfterAttributeValue;
+            }
+            else if (State == ParserState.AfterAttributeValue)
+            {
+                State = ParserState.InsideElement;
+            }
+            return true;
         }
-        
+
         public string GetParentTagName(int level)
         {
             if (NestingLevel - level - 1 < 0)
@@ -201,14 +243,70 @@ namespace Avalonia.Ide.CompletionEngine
 
         public static XmlParser Parse(ReadOnlyMemory<char> data)
         {
-            var rv = new XmlParser(data);
-            rv.Parse();
+            return Parse(data, 0, data.Length);
+        }
+
+        public static XmlParser Parse(ReadOnlyMemory<char> data, int start, int end)
+        {
+            var rv = new XmlParser(data, start);
+            for (var i = start; i < end; i++)
+            {
+                if (!rv.ParseChar())
+                {
+                    break;
+                }
+            }
+
             return rv;
+        }
+
+        /// <summary>
+        /// Try parsing until closing tag is found
+        /// </summary>
+        public bool SeekClosingTag()
+        {
+            while (State == ParserState.StartElement)
+            {
+                if (!ParseChar())
+                {
+                    return false;
+                }
+                // leave initial start element
+            }
+
+            while (NestingLevel != 0)
+            {
+                if (!ParseChar())
+                {
+                    return false;
+                }
+                // find next element at same level in document
+            }
+
+            while (State != ParserState.StartElement)
+            {
+                if (!ParseChar())
+                {
+                    return false;
+                }
+                // find start of next element
+            }
+
+            return true;
         }
 
         public override string ToString()
         {
             return $"State: {State}, TagName: {TagName}, AttributeName: {AttributeName}, Attribute: {AttributeValue}, ContainingTagStart: {ContainingTagStart}";
+        }
+
+        /// <summary>
+        /// Clone this parser state
+        /// </summary>
+        /// <returns></returns>
+        public XmlParser Clone()
+        {
+            return (XmlParser)MemberwiseClone();
         }
     }
 }

--- a/tests/CompletionEngineTests/Manipulator/ClosingTagsTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/ClosingTagsTests.cs
@@ -11,9 +11,21 @@ namespace CompletionEngineTests.Manipulator
         }
 
         [Fact]
+        public void DoNotInsertEndingTwice()
+        {
+            AssertInsertion("<Tag$ >", "/", "<Tag/ >");
+        }
+
+        [Fact]
         public void CloseTagWithSlash()
         {
             AssertInsertion("<Tag$", "/", "<Tag/>");
+        }
+
+        [Fact]
+        public void CloseTagAdvancedInContainedTag()
+        {
+            AssertInsertion("<Grid><Tag Attribute=\"\"$></Tag></Grid>", "/", "<Grid><Tag Attribute=\"\"/></Grid>");
         }
 
         [Fact]
@@ -22,6 +34,17 @@ namespace CompletionEngineTests.Manipulator
             AssertInsertion("<Tag$></Tag>", "/", "<Tag/>");
         }
 
+        [Fact]
+        public void ConvertTagWithAttributesToSelfClosingWithSlash()
+        {
+            AssertInsertion("<Tag Attribute=\"value\"$></Tag>", "/", "<Tag Attribute=\"value\"/>");
+        }
+
+        [Fact]
+        public void DoNotConvertTagsWithNestedTag()
+        {
+            AssertInsertion("<Tag$><Foo/></Tag>", "/", "<Tag/><Foo/></Tag>");
+        }
 
         [Fact]
         public void DoNotCloseTagWithAngleBracket()

--- a/tests/CompletionEngineTests/Manipulator/ClosingTagsTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/ClosingTagsTests.cs
@@ -1,0 +1,22 @@
+﻿using Xunit;
+
+namespace CompletionEngineTests.Manipulator
+{
+    public class ClosingTagsTests : ManipulatorTestBase
+    {
+        [Fact]
+        public void CloseEmptyTag()
+        {
+            AssertInsertion("<Tag$", "/", "<Tag/>");
+        }
+
+        [Fact]
+        public void DoesNotCloseTags()
+        {
+            // NOTE: Visual studio closes tags by itself, so we cannot implement this in completion engine
+            // In visual studio result of such operation will be <Tag></Tag>
+            AssertInsertion("<Tag$", ">", "<Tag>");
+        }
+
+    }
+}

--- a/tests/CompletionEngineTests/Manipulator/ClosingTagsTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/ClosingTagsTests.cs
@@ -5,13 +5,26 @@ namespace CompletionEngineTests.Manipulator
     public class ClosingTagsTests : ManipulatorTestBase
     {
         [Fact]
-        public void CloseEmptyTag()
+        public void DoNotCloseEmptyTag()
+        {
+            AssertInsertion("<$", "/", "</");
+        }
+
+        [Fact]
+        public void CloseTagWithSlash()
         {
             AssertInsertion("<Tag$", "/", "<Tag/>");
         }
 
         [Fact]
-        public void DoesNotCloseTags()
+        public void ConvertTagToSelfClosingWithSlash()
+        {
+            AssertInsertion("<Tag$></Tag>", "/", "<Tag/>");
+        }
+
+
+        [Fact]
+        public void DoNotCloseTagWithAngleBracket()
         {
             // NOTE: Visual studio closes tags by itself, so we cannot implement this in completion engine
             // In visual studio result of such operation will be <Tag></Tag>

--- a/tests/CompletionEngineTests/Manipulator/ManipulatorBasicTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/ManipulatorBasicTests.cs
@@ -10,13 +10,13 @@ namespace CompletionEngineTests.Manipulator
     public class ManipulatorBasicTests : ManipulatorTestBase
     {
         [Fact]
-        public void DoesNotInsertToUnclosedTag()
+        public void DoNotInsertToUnclosedTag()
         {
             AssertInsertion("<Alpha$><Alpha>", "Beta", "<AlphaBeta><Alpha>");
         }
 
         [Fact]
-        public void DoesNotInsertToAnotherTag()
+        public void DoNotInsertToAnotherTag()
         {
             AssertInsertion("<Alpha$><Gamma>", "Beta", "<AlphaBeta><Gamma>");
         }
@@ -98,12 +98,6 @@ namespace CompletionEngineTests.Manipulator
         public void DoNotInsertWhitespace()
         {
             AssertInsertion("<Alpha$></Alpha>", "A O", "<AlphaA O></Alpha>");
-        }
-
-        [Fact]
-        public void DoNotInsertClosingTag()
-        {
-            AssertInsertion("<Alpha$></Alpha>", "/", "<Alpha/></Alpha>");
         }
 
         [Fact]

--- a/tests/CompletionEngineTests/Manipulator/ManipulatorBasicTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/ManipulatorBasicTests.cs
@@ -9,13 +9,11 @@ namespace CompletionEngineTests.Manipulator
 
     public class ManipulatorBasicTests : ManipulatorTestBase
     {
-
         [Fact]
         public void DoesNotInsertToUnclosedTag()
         {
             AssertInsertion("<Alpha$><Alpha>", "Beta", "<AlphaBeta><Alpha>");
         }
-
 
         [Fact]
         public void DoesNotInsertToAnotherTag()
@@ -94,6 +92,43 @@ namespace CompletionEngineTests.Manipulator
         public void ReplacesInClosingTagAtEnd()
         {
             AssertReplacement("<AlphaBeta$Omega$></AlphaBetaOmega>", "Gamma", "<AlphaBetaGamma></AlphaBetaGamma>");
+        }
+
+        [Fact]
+        public void DoNotInsertWhitespace()
+        {
+            AssertInsertion("<Alpha$></Alpha>", "A O", "<AlphaA O></Alpha>");
+        }
+
+        [Fact]
+        public void DoNotInsertClosingTag()
+        {
+            AssertInsertion("<Alpha$></Alpha>", "/", "<Alpha/></Alpha>");
+        }
+
+        [Fact]
+        public void DoNotCloseTag()
+        {
+            AssertInsertion("<Alpha$></Alpha>", ">", "<Alpha>></Alpha>");
+        }
+
+        [Fact]
+        public void DoNotRemoveTag()
+        {
+            AssertReplacement("$<$Alpha></Alpha>", "a", "aAlpha></Alpha>");
+            AssertReplacement("<Alpha$>$</Alpha>", "a", "<Alphaa</Alpha>");
+        }
+
+        [Theory]
+        [InlineData(".")]
+        [InlineData("_")]
+        [InlineData("-")]
+        [InlineData("a")]
+        [InlineData("Ą")]
+        [InlineData("1")]
+        public void InsertsSpecialCharacters(string s)
+        {
+            AssertInsertion("<Alpha$><Alpha>", s, "<Alpha" + s +"><Alpha>");
         }
     }
 }

--- a/tests/CompletionEngineTests/Manipulator/ManipulatorBasicTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/ManipulatorBasicTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Avalonia.Ide.CompletionEngine;
+using Xunit;
+
+namespace CompletionEngineTests.Manipulator
+{
+
+    public class ManipulatorBasicTests : ManipulatorTestBase
+    {
+
+        [Fact]
+        public void DoesNotInsertToUnclosedTag()
+        {
+            AssertInsertion("<Alpha$><Alpha>", "Beta", "<AlphaBeta><Alpha>");
+        }
+
+
+        [Fact]
+        public void DoesNotInsertToAnotherTag()
+        {
+            AssertInsertion("<Alpha$><Gamma>", "Beta", "<AlphaBeta><Gamma>");
+        }
+
+        [Fact]
+        public void InsertsInClosingTagAtMiddle()
+        {
+            AssertInsertion("<Alpha$Beta></AlphaBeta>", "Phi", "<AlphaPhiBeta></AlphaPhiBeta>");
+        }
+
+        [Fact]
+        public void InsertsInClosingTagAtStart()
+        {
+            AssertInsertion("<$Beta></Beta>", "Alpha", "<AlphaBeta></AlphaBeta>");
+        }
+
+        [Fact]
+        public void InsertsInClosingTagAtEnd()
+        {
+            AssertInsertion("<Alpha$></Alpha>", "Beta", "<AlphaBeta></AlphaBeta>");
+        }
+
+        [Fact]
+        public void InsertsTextAtEndTagWithSubtag()
+        {
+            AssertInsertion("<Alpha$><Foo></Foo></Alpha>", "Beta", "<AlphaBeta><Foo></Foo></AlphaBeta>");
+        }
+
+        [Fact]
+        public void InsertsTextAtEndTagWithSubtagSelfClosed()
+        {
+            AssertInsertion("<Alpha$><Foo/></Alpha>", "Beta", "<AlphaBeta><Foo/></AlphaBeta>");
+        }
+
+        [Fact]
+        public void DoesNotInsertWhenIncorrectNesting()
+        {
+            AssertInsertion("<Alpha$><Foo></Alpha>", "Beta", "<AlphaBeta><Foo></Alpha>");
+        }
+
+        [Fact]
+        public void RemovesInClosingTagAtStart()
+        {
+            AssertReplacement("<$Alpha$Beta></AlphaBeta>", "", "<Beta></Beta>");
+        }
+
+        [Fact]
+        public void RemovesInClosingTagAtMiddle()
+        {
+            AssertReplacement("<Alpha$Phi$Beta></AlphaPhiBeta>", "", "<AlphaBeta></AlphaBeta>");
+        }
+
+        [Fact]
+        public void RemovesInClosingTagAtEnd()
+        {
+            AssertReplacement("<AlphaBeta$Omega$></AlphaBetaOmega>", "", "<AlphaBeta></AlphaBeta>");
+        }
+
+
+        [Fact]
+        public void ReplacesInClosingTagAtStart()
+        {
+            AssertReplacement("<$Alpha$Beta></AlphaBeta>", "Gamma", "<GammaBeta></GammaBeta>");
+        }
+
+        [Fact]
+        public void ReplacesInClosingTagAtMiddle()
+        {
+            AssertReplacement("<Alpha$Phi$Beta></AlphaPhiBeta>", "Gamma", "<AlphaGammaBeta></AlphaGammaBeta>");
+        }
+
+        [Fact]
+        public void ReplacesInClosingTagAtEnd()
+        {
+            AssertReplacement("<AlphaBeta$Omega$></AlphaBetaOmega>", "Gamma", "<AlphaBetaGamma></AlphaBetaGamma>");
+        }
+    }
+}

--- a/tests/CompletionEngineTests/Manipulator/Util/ManipulatorTestBase.cs
+++ b/tests/CompletionEngineTests/Manipulator/Util/ManipulatorTestBase.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Ide.CompletionEngine;
+using Xunit;
+
+namespace CompletionEngineTests.Manipulator
+{
+    public class ManipulatorTestBase
+    {
+        /// <summary>
+        /// Asserts that after user writes text it will be replaced
+        /// </summary>
+        /// <param name="baseText">Text, $ tag marks cursor </param>
+        /// <param name="userInput">Text to input at cursor ($)</param>
+        /// <param name="expectedOutput">Final text with replacements</param>
+        public void AssertInsertion(string baseText, string userInput, string expectedOutput)
+        {
+            (int cursor, string text) = TestUtils.PrepareTextWithCursor(baseText);
+            var inputText = baseText.Replace("$", userInput);
+
+            TextManipulator manipulator = new TextManipulator(inputText, cursor);
+
+            var change = new TextChange(cursor, userInput, cursor, "");
+            var manipulations = manipulator.ManipulateText(change);
+            var actualOutput = ApplyManipulations(inputText, manipulations);
+
+            Assert.Equal(expectedOutput, actualOutput);
+        }
+
+        /// <summary>
+        /// Asserts that after user writes text it will be replaced
+        /// </summary>
+        /// <param name="baseText">Text, $ tag marks cursor </param>
+        /// <param name="userInput">Text to input at cursor ($)</param>
+        /// <param name="expectedOutput">Final text with replacements</param>
+        public void AssertReplacement(string baseText, string userInput, string expectedOutput)
+        {
+            (int cursor, string inputText, string span) = TestUtils.PrepareTextWithSpan(baseText, userInput);
+
+            TextManipulator manipulator = new TextManipulator(inputText, cursor);
+
+            var change = new TextChange(cursor, userInput, cursor, span);
+            var manipulations = manipulator.ManipulateText(change);
+            var actualOutput = ApplyManipulations(inputText, manipulations);
+
+            Assert.Equal(expectedOutput, actualOutput);
+        }
+
+        private string ApplyManipulations(string text, IList<TextManipulation> manipulations)
+        {
+            foreach(var manipulation in manipulations)
+            {
+                if(manipulation.Type == ManipulationType.Insert)
+                {
+                    text = text.Insert(manipulation.Start, manipulation.Text);
+                }
+                if(manipulation.Type == ManipulationType.Delete)
+                {
+                    text = text.Remove(manipulation.Start, manipulation.End - manipulation.Start);
+                }
+            }
+            return text;
+        }
+    }
+
+    public class TextChange : ITextChange
+    {
+        public static TextChange Insertion(int position, string text)
+        {
+            return new TextChange(position, text, position, "");
+        }
+        public static TextChange Replacement(int position, string newText, string oldText)
+        {
+            return new TextChange(position, newText, position, oldText);
+        }
+
+        public TextChange(int newPosition, string newText, int oldPosition, string oldText)
+        {
+            (NewPosition, NewText, OldPosition, OldText) = (newPosition, newText, oldPosition, oldText);
+        }
+
+        public int NewPosition { get; set; }
+
+        public string NewText { get; set; }
+
+        public int OldPosition { get; set; }
+
+        public string OldText { get; set; }
+    }
+}

--- a/tests/CompletionEngineTests/Manipulator/Util/ManipulatorTestUtils.cs
+++ b/tests/CompletionEngineTests/Manipulator/Util/ManipulatorTestUtils.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace CompletionEngineTests.Manipulator
+{
+    class TestUtils
+    {
+        /// <summary>
+        /// Parses string with cursor marked as $ to input string and cursor position
+        /// </summary>
+        /// <param name="baseText"></param>
+        /// <returns></returns>
+        public static (int cursor, string text) PrepareTextWithCursor(string baseText)
+        {
+            var cursors = baseText.Where(n => n.Equals('$')).Count();
+            bool thereIsSingleCursor = cursors == 1;
+            Assert.True(thereIsSingleCursor);
+
+            var cursor = baseText.IndexOf("$");
+            var text = baseText.Replace("$", "");
+
+            return (cursor, text);
+        }
+
+        /// <summary>
+        /// Parses string with span of text between $$
+        /// </summary>
+        /// <param name="baseText">Text withc two $ characters</param>
+        /// <returns>Span start, text and span</returns>
+        public static (int cursor, string text, string span) PrepareTextWithSpan(string baseText, string userInput = "")
+        {
+            var cursors = baseText.Where(n => n.Equals('$')).Count();
+            bool thereIsSingleSpan = cursors == 2;
+            Assert.True(thereIsSingleSpan);
+
+            int spanStart = baseText.IndexOf("$");
+            int spanEnd = baseText.LastIndexOf("$");
+            var cursor = spanStart;
+
+            var start = baseText.Substring(0, spanStart);
+            var end = baseText.Substring(spanEnd + 1);
+            var text = start + userInput + end;
+
+            var span = baseText.Substring(spanStart + 1, spanEnd - 1 - spanStart);
+
+            return (cursor, text, span);
+        }
+    }
+}

--- a/tests/CompletionEngineTests/Manipulator/XmlParserTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/XmlParserTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Avalonia.Ide.CompletionEngine;
+using Xunit;
+
+namespace CompletionEngineTests.Manipulator
+{
+    /// <summary>
+    /// Tests for XmlParser behavior on which TextManipulator is dependent
+    /// </summary>
+    public class XmlParserTests
+    {
+        [Fact]
+        public void Should_BeInNoneState_When_OnClosingBrace()
+        {
+            var parser = XmlParser.Parse("<Grid>");
+            Assert.Equal(XmlParser.ParserState.None, parser.State);
+        }
+
+        [Fact]
+        public void Should_NotBeInClosingTag_When_StartTag()
+        {
+            var p = XmlParser.Parse("<Grid");
+            Assert.False(p.IsInClosingTag);
+        }
+
+        [Fact]
+        public void Should_BeInClosingTag_When_ParsedSlash()
+        {
+            var p = XmlParser.Parse("<Grid></");
+            Assert.True(p.IsInClosingTag);
+        }
+
+        [Fact]
+        public void Should_BeInClosingTag_When_InsideEndTag()
+        {
+            var p = XmlParser.Parse("<Grid></Grid");
+            Assert.True(p.IsInClosingTag);
+        }
+
+        [Fact]
+        public void Should_MoveBackTo0Nesting_When_ParsedClosedTag()
+        {
+            var p = XmlParser.Parse("<Grid><Foo></Foo></");
+            Assert.Equal(0, p.NestingLevel);
+        }
+
+        [Fact]
+        public void Should_MoveBackTo0Nesting_When_ParsedSelfclosedTag()
+        {
+            var p = XmlParser.Parse("<Grid><Foo/></");
+            Assert.Equal(0, p.NestingLevel);
+        }
+
+        [Fact]
+        public void Should_SeekEndTag_In_SimpleCase()
+        {
+            string data = "<Grid></Grid>";
+            int ppos = "<Grid".Length;
+            int seek = "<Grid></".Length;
+
+            var p = XmlParser.Parse(data.AsMemory(), 0, ppos);
+            var result = p.SeekClosingTag();
+
+            Assert.True(result);
+            Assert.Equal(seek, p.ParserPos);
+        }
+
+        [Fact]
+        public void Should_SeekEndTag_In_OverClosedTag()
+        {
+            string data = "<Grid><Foo/></Grid>";
+            int ppos = "<Grid".Length;
+            int seek = "<Grid><Foo/></".Length;
+
+            var p = XmlParser.Parse(data.AsMemory(), 0, ppos);
+            var result = p.SeekClosingTag();
+
+            Assert.True(result);
+            Assert.Equal(seek, p.ParserPos);
+        }
+
+        [Fact]
+        public void Should_Fail_On_InavlidNesting()
+        {
+            string data = "<Grid><Foo></Grid>";
+            int ppos = "<Grid".Length;
+            int seek = data.Length;
+
+            var p = XmlParser.Parse(data.AsMemory(), 0, ppos);
+            var result = p.SeekClosingTag();
+
+            Assert.False(result);
+            Assert.Equal(seek, p.ParserPos);
+        }
+    }
+}

--- a/tests/CompletionEngineTests/Manipulator/XmlParserTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/XmlParserTests.cs
@@ -52,6 +52,13 @@ namespace CompletionEngineTests.Manipulator
         }
 
         [Fact]
+        public void Should_ReturnCorrectTagName()
+        {
+            var p = XmlParser.Parse("<Grid><Tag Attribute=\"\"/");
+            Assert.Equal("Tag", p.ParseCurrentTagName());
+        }
+
+        [Fact]
         public void Should_SeekEndTag_In_SimpleCase()
         {
             string data = "<Grid></Grid>";


### PR DESCRIPTION
Allows editing of text as user types.

Enables features such as:

- [x] Close tag when typing /
- [x] Switch tag to self-closing when typing / in opening tag, i.e. `<Grid></Grid>` -> `<Grid/>`
- [x] Edit end tag when typing into start tag