### PR TITLE
Close tag with trailing whitespace

### DIFF
--- a/src/Avalonia.Ide.CompletionEngine/CloseXmlTagManipulation.cs
+++ b/src/Avalonia.Ide.CompletionEngine/CloseXmlTagManipulation.cs
@@ -60,11 +60,8 @@ namespace Avalonia.Ide.CompletionEngine
             {
                 return null;
             }
-
-            // skip eventual whitespaces
-
-            char c = text[pos];
-            SkipWhitespace(ref pos, text, ref c);
+            
+            pos = SkipWhitespace(pos, text);
 
             // Check next text is </closingTag>
             if (text.Length < pos + currentTag.Length + 3
@@ -84,8 +81,7 @@ namespace Avalonia.Ide.CompletionEngine
                 pos++;
             }
 
-            // parse whitespace
-            SkipWhitespace(ref pos, text, ref c);
+            pos = SkipWhitespace(pos, text);
 
             if(text.Length <= pos || text[pos] != '>')
             {
@@ -95,12 +91,16 @@ namespace Avalonia.Ide.CompletionEngine
             return pos;
         }
 
-        private static void SkipWhitespace(ref int pos, ReadOnlySpan<char> text, ref char c)
+        private static int SkipWhitespace(int pos, ReadOnlySpan<char> text)
         {
-            for (; char.IsWhiteSpace(c) && text.Length > pos + 1; pos++)
+            for (; text.Length > pos; pos++)
             {
-                c = text[pos];
+                if (!char.IsWhiteSpace(text[pos]))
+                {
+                    return pos;
+                }
             }
+            return pos;
         }
     }
 }

--- a/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
+++ b/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
@@ -308,7 +308,7 @@ namespace Avalonia.Ide.CompletionEngine
         public XmlParser Clone()
         {
             var newParser = (XmlParser)MemberwiseClone();
-            var clonedStack = = new Stack<int>(new Stack<int>(_containingTagStart));
+            var clonedStack = new Stack<int>(new Stack<int>(_containingTagStart));
             newParser._containingTagStart = clonedStack;
             return newParser;
         }

--- a/tests/CompletionEngineTests/BasicTests.cs
+++ b/tests/CompletionEngineTests/BasicTests.cs
@@ -12,6 +12,12 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void Property_Should_Be_Renamed()
+        {
+            AssertSingleCompletionInMiddleOfText("<UserControl ", "=\"Top\"","HorizontalAlign", "HorizontalAlignment");
+        }
+
+        [Fact]
         public void Property_Should_Be_Completed()
         {
             AssertSingleCompletion("<UserControl ", "HorizontalAlign", "HorizontalAlignment=\"\"");
@@ -54,6 +60,12 @@ namespace CompletionEngineTests
         public void AttachedProperty_Should_Be_Completed()
         {
             AssertSingleCompletion("<UserControl Grid.", "Ro", "Row=\"\"");
+        }
+
+        [Fact]
+        public void AttachedProperty_Should_Be_Renamed()
+        {
+            AssertSingleCompletionInMiddleOfText("<UserControl Grid.", "=\"2\"", "Ro", "Row");
         }
 
         [Fact]

--- a/tests/CompletionEngineTests/Manipulator/ClosingTagsTests.cs
+++ b/tests/CompletionEngineTests/Manipulator/ClosingTagsTests.cs
@@ -54,5 +54,10 @@ namespace CompletionEngineTests.Manipulator
             AssertInsertion("<Tag$", ">", "<Tag>");
         }
 
+        [Fact]
+        public void CloseTagWithTrailingWhitespace()
+        {
+            AssertInsertion("<MenuItem Header=\"Header\" $>\r\n      </MenuItem >", "/", @"<MenuItem Header=""Header"" />");
+        }
     }
 }

--- a/tests/CompletionEngineTests/XamlCompletionTestBase.cs
+++ b/tests/CompletionEngineTests/XamlCompletionTestBase.cs
@@ -31,17 +31,17 @@ namespace CompletionEngineTests
             };
         }
 
-        protected CompletionSet GetCompletionsFor(string xaml)
+        protected CompletionSet GetCompletionsFor(string xaml, string xamlAfterCursor ="")
         {
             xaml = Prologue + xaml;
             var engine = new CompletionEngine();
-            var set = engine.GetCompletions(Metadata, xaml, xaml.Length, Assembly.GetCallingAssembly().GetName().Name);
+            var set = engine.GetCompletions(Metadata, xaml + xamlAfterCursor, xaml.Length, Assembly.GetCallingAssembly().GetName().Name);
             return TransformCompletionSet(set);
         }
 
-        protected void AssertSingleCompletion(string xaml, string typed, string completion)
+        protected void AssertSingleCompletionInMiddleOfText(string xaml, string xamlAfterCursor, string typed, string completion)
         {
-            var comp = GetCompletionsFor(xaml + typed);
+            var comp = GetCompletionsFor(xaml + typed, xamlAfterCursor);
             if (comp == null)
                 throw new Exception("No completions found");
 
@@ -50,6 +50,12 @@ namespace CompletionEngineTests
             Assert.Contains(comp.Completions, c => c.InsertText == completion);
 
             Assert.Single(comp.Completions, c => c.InsertText == completion);
+
+        }
+
+        protected void AssertSingleCompletion(string xaml, string typed, string completion)
+        {
+            AssertSingleCompletionInMiddleOfText(xaml, "", typed, completion);
         }
     }
 }


### PR DESCRIPTION
Collapse tags with space after closing tag name, like:
`<Menu></Menu >` => `<Menu/>`

Also simplify `ClosedXmlTagManipulation` a bit.