### PR TITLE
Add event completion in xaml

### DIFF
--- a/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
+++ b/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
@@ -51,7 +51,12 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
         public string Namespace => _type.Namespace;
         public ITypeInformation GetBaseType() => FromDef(_type.GetBaseType().ResolveTypeDef());
 
+
+        public IEnumerable<IEventInformation> Events => _type.Events.Select(e => new EventWrapper(e));
+
         public IEnumerable<IMethodInformation> Methods => _type.Methods.Select(m => new MethodWrapper(m));
+
+        public IEnumerable<IFieldInformation> Fields => _type.Fields.Select(f => new FieldWrapper(f));
 
         public IEnumerable<IPropertyInformation> Properties => _type.Properties
             //Filter indexer properties
@@ -134,6 +139,38 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
         public string TypeFullName { get; }
         public string Name { get; }
         public override string ToString() => Name;
+    }
+
+    class FieldWrapper : IFieldInformation
+    {
+        public FieldWrapper(FieldDef f)
+        {
+            IsStatic = f.IsStatic;
+            IsPublic = f.IsPublic || f.IsAssembly;
+            Name = f.Name;
+            ReturnTypeFullName = f.FieldType.FullName;
+        }
+
+        public bool IsStatic { get; }
+
+        public bool IsPublic { get; }
+
+        public string Name { get; }
+
+        public string ReturnTypeFullName { get; }
+    }
+
+    class EventWrapper : IEventInformation
+    {
+        public EventWrapper(EventDef @event)
+        {
+            Name = @event.Name;
+            TypeFullName = @event.EventType.FullName;
+        }
+
+        public string Name { get; }
+
+        public string TypeFullName { get; }
     }
 
     class MethodWrapper : IMethodInformation

--- a/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
+++ b/src/Avalonia.Ide.CompletionEngine.DnlibMetadataProvider/Wrappers.cs
@@ -149,7 +149,23 @@ namespace Avalonia.Ide.CompletionEngine.DnlibMetadataProvider
             IsPublic = f.IsPublic || f.IsAssembly;
             Name = f.Name;
             ReturnTypeFullName = f.FieldType.FullName;
+
+            bool isRoutedEvent = false;
+            ITypeDefOrRef t = f.FieldType.ToTypeDefOrRef();
+            while(t != null)
+            {
+                if(t.Name == "RoutedEvent" && t.Namespace == "Avalonia.Interactivity")
+                {
+                    isRoutedEvent = true;
+                    break;
+                }
+                t = t.GetBaseType();
+            }
+
+            IsRoutedEvent = isRoutedEvent;
         }
+
+        public bool IsRoutedEvent { get; }
 
         public bool IsStatic { get; }
 

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyInformation.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyInformation.cs
@@ -31,6 +31,9 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
         ITypeInformation GetBaseType();
         IEnumerable<IMethodInformation> Methods { get; }
         IEnumerable<IPropertyInformation> Properties { get; }
+        IEnumerable<IEventInformation> Events { get; }
+        IEnumerable<IFieldInformation> Fields { get; }
+
         bool IsEnum { get; }
         bool IsStatic { get; }
         bool IsInterface { get; }
@@ -49,6 +52,14 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
         string ReturnTypeFullName { get; }
     }
 
+    public interface IFieldInformation
+    {
+        bool IsStatic { get; }
+        bool IsPublic { get; }
+        string Name { get; }
+        string ReturnTypeFullName { get; }
+    }
+
     public interface IParameterInformation
     {
         string TypeFullName { get; }
@@ -61,5 +72,11 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
         bool HasPublicGetter { get; }
         string TypeFullName { get; }
         string Name { get; }
+    }
+
+    public interface IEventInformation
+    {
+        string Name { get; }
+        string TypeFullName { get; }
     }
 }

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyInformation.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/IAssemblyInformation.cs
@@ -58,6 +58,7 @@ namespace Avalonia.Ide.CompletionEngine.AssemblyMetadata
         bool IsPublic { get; }
         string Name { get; }
         string ReturnTypeFullName { get; }
+        bool IsRoutedEvent { get; }
     }
 
     public interface IParameterInformation

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
@@ -30,7 +30,9 @@ namespace Avalonia.Ide.CompletionEngine
         public string Name { get; set; }
         public string FullName { get; set; } = "";
         public List<MetadataProperty> Properties { get; set; } = new List<MetadataProperty>();
+        public List<MetadataEvent> Events { get; set; } = new List<MetadataEvent>();
         public bool HasAttachedProperties { get; set; }
+        public bool HasAttachedEvents { get; set; }
         public bool HasStaticGetProperties { get; set; }
         public bool HasSetProperties { get; set; }
         public bool IsAvaloniaObjectType { get; set; }
@@ -52,13 +54,13 @@ namespace Avalonia.Ide.CompletionEngine
     [DebuggerDisplay("{Name} from {DeclaringType}")]
     public class MetadataProperty
     {
-        public string Name { get; set; }
+        public string Name { get; }
         public MetadataType Type { get; set; }
-        public MetadataType DeclaringType { get; set; }
-        public bool IsAttached { get; set; }
-        public bool IsStatic { get; set; }
-        public bool HasGetter { get; set; }
-        public bool HasSetter { get; set; }
+        public MetadataType DeclaringType { get; }
+        public bool IsAttached { get; }
+        public bool IsStatic { get; }
+        public bool HasGetter { get; }
+        public bool HasSetter { get; }
 
         public MetadataProperty(string name, MetadataType type, MetadataType declaringType, bool isAttached, bool isStatic, bool hasGetter, bool hasSetter)
         {
@@ -71,4 +73,20 @@ namespace Avalonia.Ide.CompletionEngine
             HasSetter = hasSetter;
         }
     }
+
+    public class MetadataEvent
+    {
+        public MetadataEvent(string name, MetadataType type, MetadataType declaringType, bool isAttached)
+        {
+            Name = name;
+            Type = type;
+            DeclaringType = declaringType;
+            IsAttached = isAttached;
+        }
+        public string Name { get; }
+        public bool IsAttached { get; }
+        public MetadataType Type { get; }
+        public MetadataType DeclaringType { get; }
+    }
+
 }

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -152,11 +152,9 @@ namespace Avalonia.Ide.CompletionEngine
 
                         foreach (var fieldDef in typeDef.Fields)
                         {
-                            if (fieldDef.IsStatic && fieldDef.IsPublic
-                                && 
-                                (fieldDef.ReturnTypeFullName.StartsWith("RoutedEvent") || 
-                                fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase))
-                                )
+                            if (fieldDef.IsStatic && fieldDef.IsPublic &&
+                                (fieldDef.IsRoutedEvent 
+                                || fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase)))
                             {
                                 var name = fieldDef.Name;
                                 if(fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase))

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -126,12 +126,20 @@ namespace Avalonia.Ide.CompletionEngine
                         type.Properties.Add(p);
                     }
 
+                    foreach (var eventDef in typeDef.Events)
+                    {
+                        var e = new MetadataEvent(eventDef.Name, types.GetValueOrDefault(eventDef.TypeFullName),
+                            types.GetValueOrDefault(typeDef.FullName), false);
+
+                        type.Events.Add(e);
+                    }
+
                     //check for attached properties only on top level
                     if (level == 0)
                     {
                         foreach (var methodDef in typeDef.Methods)
                         {
-                            if (methodDef.Name.StartsWith("Set") && methodDef.IsStatic && methodDef.IsPublic
+                            if (methodDef.Name.StartsWith("Set", StringComparison.OrdinalIgnoreCase) && methodDef.IsStatic && methodDef.IsPublic
                                 && methodDef.Parameters.Count == 2)
                             {
                                 var name = methodDef.Name.Substring(3);
@@ -139,6 +147,27 @@ namespace Avalonia.Ide.CompletionEngine
                                     types.GetValueOrDefault(methodDef.Parameters[1].TypeFullName),
                                     types.GetValueOrDefault(typeDef.FullName),
                                     true, false, true, true));
+                            }
+                        }
+
+                        foreach (var fieldDef in typeDef.Fields)
+                        {
+                            if (fieldDef.IsStatic && fieldDef.IsPublic
+                                && 
+                                (fieldDef.ReturnTypeFullName.StartsWith("RoutedEvent") || 
+                                fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase))
+                                )
+                            {
+                                var name = fieldDef.Name;
+                                if(fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    name = name.Substring(0, name.Length - "Event".Length);
+                                }
+
+                                type.Events.Add(new MetadataEvent(name,
+                                    types.GetValueOrDefault(fieldDef.ReturnTypeFullName),
+                                    types.GetValueOrDefault(typeDef.FullName),
+                                    true));
                             }
                         }
                     }
@@ -153,6 +182,7 @@ namespace Avalonia.Ide.CompletionEngine
                 }
 
                 type.HasAttachedProperties = type.Properties.Any(p => p.IsAttached);
+                type.HasAttachedEvents = type.Events.Any(e => e.IsAttached);
                 type.HasStaticGetProperties = type.Properties.Any(p => p.IsStatic && p.HasGetter);
                 type.HasSetProperties = type.Properties.Any(p => !p.IsStatic && p.HasSetter);
 

--- a/src/Avalonia.Ide.CompletionEngine/Completion.cs
+++ b/src/Avalonia.Ide.CompletionEngine/Completion.cs
@@ -13,7 +13,9 @@ namespace Avalonia.Ide.CompletionEngine
         StaticProperty,
         Namespace,
         Enum,
-        MarkupExtension
+        MarkupExtension,
+        Event,
+        AttachedEvent
     }
 
     public class Completion

--- a/tests/CompletionEngineTests/Metadata/MetadataConverterTests.cs
+++ b/tests/CompletionEngineTests/Metadata/MetadataConverterTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Ide.CompletionEngine;
+using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
+using Avalonia.Ide.CompletionEngine.DnlibMetadataProvider;
+using Xunit;
+
+namespace CompletionEngineTests
+{
+    public class MetadataConverterTests
+    {
+        [Fact]
+        public void DiscoverAttachedEvent_IfItIsDerivedFromRoutedEvent()
+        {
+            Type clrType = typeof(MetadataTestClass);
+            string nsName = "clr-namespace:" + clrType.Namespace + ";assembly=" + typeof(MetadataTestClass).Assembly.GetName().Name;
+            Dictionary<string, MetadataType> ns = Metadata.Namespaces[nsName];
+            MetadataType type = ns[clrType.Name];
+
+            var attachedEvent = type.Events.Single();
+            Assert.True(attachedEvent.Type.FullName == typeof(MetadataTestClass).FullName);
+        }
+
+        private static Metadata Metadata = new MetadataReader(new DnlibMetadataProvider())
+            .GetForTargetAssembly(typeof(XamlCompletionTestBase).Assembly.GetModules()[0].FullyQualifiedName);
+    }
+}

--- a/tests/CompletionEngineTests/Metadata/MetadataTestClass.cs
+++ b/tests/CompletionEngineTests/Metadata/MetadataTestClass.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Avalonia.Ide.CompletionEngine.DnlibMetadataProvider;
+using Avalonia.Interactivity;
+
+namespace CompletionEngineTests
+{
+    /// <summary>
+    /// This class should not have Event in name
+    /// as it is used to check if discovery of attached events is working,
+    /// see <see cref="FieldWrapper"/>
+    /// </summary>
+    public class MetadataTestClass : RoutedEvent
+    {
+        /// <summary>
+        /// Field which should be recognized as attached event,
+        /// as its declaring type is sublcass of <see cref="RoutedEvent"/>
+        /// </summary>
+        public static MetadataTestClass field;
+
+        public MetadataTestClass(string name, RoutingStrategies routingStrategies, Type eventArgsType, Type ownerType) : base(name, routingStrategies, eventArgsType, ownerType)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## What does the pull request do?
Add intellisense completion for event and attached events

## What is the current behavior?
There is no completion for event or attached event


## What is the updated/expected behavior with this PR?
When typing name of event it is completed.
When typing name of type, which has attached events it is completed
When typing name of type, which has attached events + dot it will complete event name
Try typing event name ie. `KeyUp` on control, or `Gestures.*` for attached event

## How was the solution implemented (if it's not obvious)?
Events are straightforward. Dnlib does not differentiate between public and private events (idk if this is how framework works), so all are provided.

For attached properties I am looking for public static fields and (return type starts with `RoutedEvent` `or` name ends with `Event`).
I am not sure if `or` should be changed to `and`. Also maybe there is need for checking static properties?

## Fixed issues
https://github.com/AvaloniaUI/AvaloniaVS/issues/133

Also check PR on AvaloniaVS:
https://github.com/AvaloniaUI/AvaloniaVS/pull/167