### PR TITLE
add some more completions and fix current

### DIFF
--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/Metadata.cs
@@ -40,6 +40,14 @@ namespace Avalonia.Ide.CompletionEngine
         public bool IsCompositeValue { get; set; }
         public bool IsGeneric { get; set; }
         public bool IsXamlDirective { get; set; }
+
+        public MetadataType CloneAs(string name, string fullName)
+        {
+            var result = (MetadataType)MemberwiseClone();
+            result.Name = name;
+            result.FullName = fullName;
+            return result;
+        }
     }
 
     public enum MetadataTypeCtorArgument

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -502,23 +502,17 @@ namespace Avalonia.Ide.CompletionEngine
 
             types.Add(xamlResType.Name, xamlResType);
 
-            MetadataType avProperty;
+            var allProps = new Dictionary<string, MetadataProperty>();
 
-            if (types.TryGetValue("Avalonia.AvaloniaProperty", out avProperty))
+            foreach (var type in types.Where(t => t.Value.IsAvaloniaObjectType))
             {
-                var allProps = new Dictionary<string, MetadataProperty>();
-
-                foreach (var type in types.Where(t => t.Value.IsAvaloniaObjectType))
+                foreach (var v in type.Value.Properties.Where(p => p.HasSetter && p.HasGetter))
                 {
-                    foreach (var v in type.Value.Properties.Where(p => p.HasSetter && p.HasGetter))
-                    {
-                        allProps[v.Name] = v;
-                    }
+                    allProps[v.Name] = v;
                 }
-
-                avProperty.HasHintValues = true;
-                avProperty.HintValues = allProps.Keys.ToArray();
             }
+
+            string[] allAvaloniaProps = allProps.Keys.ToArray();
 
             if (!types.TryGetValue("Avalonia.Markup.Xaml.MarkupExtensions.BindingExtension", out MetadataType bindingExtType))
             {
@@ -563,8 +557,8 @@ namespace Avalonia.Ide.CompletionEngine
                     IsMarkupExtension = true,
                     Properties = templBinding.Properties,
                     SupportCtorArgument = MetadataTypeCtorArgument.HintValues,
-                    HasHintValues = avProperty?.HasHintValues ?? false,
-                    HintValues = avProperty?.HintValues
+                    HasHintValues = allAvaloniaProps?.Any() ?? false,
+                    HintValues = allAvaloniaProps
                 };
 
                 types["TemplateBindingExtension"] = tbext;

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -365,6 +365,7 @@ namespace Avalonia.Ide.CompletionEngine
                 new MetadataType(){ Name = typeof(System.Type).FullName },
                 new MetadataType(){ Name = "Avalonia.Media.IBrush" },
                 new MetadataType(){ Name = "Avalonia.Media.Imaging.IBitmap" },
+                new MetadataType(){ Name = "Avalonia.Media.IImage" },
             };
 
             foreach (var t in toAdd)
@@ -501,6 +502,20 @@ namespace Avalonia.Ide.CompletionEngine
                 avProperty.HintValues = allProps.Keys.ToArray();
             }
 
+            if (!types.TryGetValue("Avalonia.Markup.Xaml.MarkupExtensions.BindingExtension", out MetadataType bindingExtType))
+            {
+                if (types.TryGetValue("Avalonia.Data.Binding", out MetadataType origBindingType))
+                {
+                    //avalonia 0.10 has implicit binding extension
+                    bindingExtType = origBindingType.CloneAs("BindingExtension",
+                        "Avalonia.Markup.Xaml.MarkupExtensions.BindingExtension");
+                    bindingExtType.IsMarkupExtension = true;
+
+                    types.Add(bindingExtType.FullName, bindingExtType);
+                    metadata.AddType(Utils.AvaloniaNamespace, bindingExtType);
+                }
+            }
+
             //bindings related hints
             if (types.TryGetValue("Avalonia.Markup.Xaml.MarkupExtensions.BindingExtension", out MetadataType bindingType))
             {
@@ -596,6 +611,13 @@ namespace Avalonia.Ide.CompletionEngine
                 ibitmapType.HasHintValues = true;
                 ibitmapType.HintValues = allresourceUrls.Where(r => isbitmaptype(r)).ToArray();
                 ibitmapType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(ibitmapType, a);
+            }
+
+            if (types.TryGetValue("Avalonia.Media.IImage", out MetadataType iImageType))
+            {
+                iImageType.HasHintValues = true;
+                iImageType.HintValues = allresourceUrls.Where(r => isbitmaptype(r)).ToArray();
+                iImageType.XamlContextHintValuesFunc = (a, t, p) => filterLocalRes(ibitmapType, a);
             }
 
             if (types.TryGetValue("Avalonia.Controls.WindowIcon", out MetadataType winIcon))

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -353,16 +353,17 @@ namespace Avalonia.Ide.CompletionEngine
 
         private static void PreProcessTypes(Dictionary<string, MetadataType> types, Metadata metadata)
         {
+            MetadataType xDataType, xCompiledBindings, boolType, typeType;
             var toAdd = new List<MetadataType>
             {
-                new MetadataType()
+                (boolType = new MetadataType()
                 {
                     Name = typeof(bool).FullName,
                     HasHintValues = true,
                     HintValues = new[] { "True", "False" }
-                },
+                }),
                 new MetadataType(){ Name = typeof(System.Uri).FullName },
-                new MetadataType(){ Name = typeof(System.Type).FullName },
+                (typeType = new MetadataType(){ Name = typeof(System.Type).FullName }),
                 new MetadataType(){ Name = "Avalonia.Media.IBrush" },
                 new MetadataType(){ Name = "Avalonia.Media.Imaging.IBitmap" },
                 new MetadataType(){ Name = "Avalonia.Media.IImage" },
@@ -408,6 +409,18 @@ namespace Avalonia.Ide.CompletionEngine
                     Name = "Key",
                     IsXamlDirective = true
                 },
+                xDataType = new MetadataType()
+                {
+                    Name = "DataType",
+                    IsXamlDirective = true,
+                    Properties = { new MetadataProperty("", typeType,null, false, false, false, true)},
+                },
+                xCompiledBindings = new MetadataType()
+                {
+                    Name = "CompileBindings",
+                    IsXamlDirective = true,
+                    Properties = { new MetadataProperty("", boolType,null, false, false, false, true)},
+                },
             };
 
             //as in avalonia 0.9 Portablexaml is missing we need to hardcode some extensions
@@ -415,6 +428,9 @@ namespace Avalonia.Ide.CompletionEngine
             {
                 metadata.AddType(Utils.Xaml2006Namespace, t);
             }
+
+            types.Add(xDataType.Name, xDataType);
+            types.Add(xCompiledBindings.Name, xCompiledBindings);
 
             metadata.AddType("", new MetadataType() { Name = "xmlns", IsXamlDirective = true });
         }

--- a/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
+++ b/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Ide.CompletionEngine
                     ? _attributeNameStart
                     : State == ParserState.AttributeValue
                         ? _attributeValueStart
-                        : (int?) null;
+                        : (int?)null;
 
         public int? ElementNameEnd => State >= ParserState.StartElement ? _elementNameEnd : null;
 
@@ -74,7 +74,7 @@ namespace Avalonia.Ide.CompletionEngine
 
         private const string CdataStart = "![CDATA[";
         private const string CdataEnd = "]]>";
-        
+
         bool CheckPrev(int caret, string checkFor)
         {
             var startAt = caret - checkFor.Length + 1;
@@ -91,7 +91,7 @@ namespace Avalonia.Ide.CompletionEngine
 
         private bool ParseChar()
         {
-            if(_parserPos >= _data.Length)
+            if (_parserPos >= _data.Length)
             {
                 return false;
             }
@@ -200,13 +200,13 @@ namespace Avalonia.Ide.CompletionEngine
             return null;
 
         }
-        
-        public string FindParentAttributeValue(string attributeExpr, int startLevel = 0)
+
+        public string FindParentAttributeValue(string attributeExpr, int startLevel = 0, int maxLevels = int.MaxValue)
         {
             if (NestingLevel - startLevel - 1 < 0)
                 return null;
-            var attribRegExpr = new Regex($"\\s(?:{attributeExpr})=\"(?<AttribValue>[\\w\\:]*)\"");
-            foreach(var start in _containingTagStart.Skip(startLevel))
+            var attribRegExpr = new Regex($"\\s(?:{attributeExpr})=\"(?<AttribValue>[\\w\\:\\s\\|\\.]+)\"");
+            foreach (var start in _containingTagStart.Skip(startLevel))
             {
                 var m = Regex.Match(_data.Span.Slice(start).ToString(), @"^<[^>]+");
                 if (m.Success)
@@ -218,6 +218,7 @@ namespace Avalonia.Ide.CompletionEngine
                         return attribMatch.Groups["AttribValue"].Value;
                     }
                 }
+                if (--maxLevels < 0) break;
             }
 
             return null;

--- a/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
+++ b/src/Avalonia.Ide.CompletionEngine/XmlParser.cs
@@ -200,6 +200,28 @@ namespace Avalonia.Ide.CompletionEngine
             return null;
 
         }
+        
+        public string FindParentAttributeValue(string attributeExpr, int startLevel = 0)
+        {
+            if (NestingLevel - startLevel - 1 < 0)
+                return null;
+            var attribRegExpr = new Regex($"\\s(?:{attributeExpr})=\"(?<AttribValue>[\\w\\:]*)\"");
+            foreach(var start in _containingTagStart.Skip(startLevel))
+            {
+                var m = Regex.Match(_data.Span.Slice(start).ToString(), @"^<[^>]+");
+                if (m.Success)
+                {
+                    var tagNameWithAttributes = m.Value.Substring(1);
+                    var attribMatch = attribRegExpr.Match(tagNameWithAttributes);
+                    if (attribMatch.Success)
+                    {
+                        return attribMatch.Groups["AttribValue"].Value;
+                    }
+                }
+            }
+
+            return null;
+        }
 
         public string ParseCurrentTagName()
         {

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -57,6 +57,12 @@ namespace CompletionEngineTests
         {
             AssertSingleCompletion("<DataTemplate DataType=\"{x:Type ", "But", "Button");
         }
+        
+        [Fact]
+        public void Extension_DataType_Types_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<UserControl x:DataType=\"", "But", "Button");
+        }
 
         [Fact]
         public void Property_Of_Type_Type_Type_Should_Be_Completed()

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -51,6 +51,48 @@ namespace CompletionEngineTests
         {
             AssertSingleCompletion("<UserControl Background=\"{Binding RelativeSource={RelativeSource ", "Se", "Self");
         }
+        
+        [Fact]
+        public void Binding_Path_Should_Be_Completed_From_xDataType()
+        {
+            AssertSingleCompletion("<UserControl x:DataType=\"Button\"><TextBlock Tag=\"{Binding Path=", "Conte", "Content");
+        }
+        
+        [Fact]
+        public void Binding_Path_Should_Be_Completed_From_xDataType2()
+        {
+            AssertSingleCompletion("<UserControl x:DataType=\"Button\"><TextBlock Tag=\"{Binding ", "Conte", "Content");
+        }
+        
+        [Fact]
+        public void Binding_Path_Should_Be_Completed_From_sParent()
+        {
+            AssertSingleCompletion("<UserControl Background=\"{Binding ", "$pa", "$parent[");
+        }
+        
+        [Fact]
+        public void Binding_Path_Should_Be_Completed_From_sParentType()
+        {
+            AssertSingleCompletion("<UserControl Background=\"{Binding ", "$parent[But", "$parent[Button].");
+        }
+        
+        [Fact]
+        public void Binding_Path_Should_Be_Completed_From_sParentType_Property()
+        {
+            AssertSingleCompletion("<UserControl Background=\"{Binding ", "$parent[Button].Ta", "$parent[Button].Tag");
+        }
+        
+        [Fact]
+        public void Binding_Path_Should_Be_Completed_From_sParent_Property()
+        {
+            AssertSingleCompletion("<UserControl Background=\"{Binding ", "$parent.Ta", "$parent.Tag");
+        }
+
+        [Fact]
+        public void Binding_Path_Should_Be_Completed_From_sParent_Property_Nested()
+        {
+            AssertSingleCompletion("<UserControl Background=\"{Binding ", "$parent.Bounds.Wi", "$parent.Bounds.Width");
+        }
 
         [Fact]
         public void Extension_With_CtorArgument_Type_Should_Be_Completed()

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -75,7 +75,13 @@ namespace CompletionEngineTests
         {
             AssertSingleCompletion("<UserControl Background=\"{Binding ", "$parent[But", "$parent[Button].");
         }
-        
+
+        [Fact]
+        public void Binding_Path_Should_Be_Completed_From_xName()
+        {
+            AssertSingleCompletion("<UserControl x:Name=\"foo\" Tag=\"{Binding ", "#f", "#foo");
+        }
+
         [Fact]
         public void Binding_Path_Should_Be_Completed_From_sParentType_Property()
         {

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -146,6 +146,36 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void Style_Property_Name_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<Style Selector=\"Button\"><Setter Property=\"", "HorizontalAli", "HorizontalAlignment");
+        }
+
+        [Fact]
+        public void Style_Attached_Property_Class_Name_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<Style Selector=\"Button\"><Setter Property=\"", "TextBl", "TextBlock");
+        }
+
+        [Fact]
+        public void Style_Attached_Property_Name_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<Style Selector=\"Button\"><Setter Property=\"", "TextBlock.FontWe", "TextBlock.FontWeight");
+        }
+
+        [Fact]
+        public void Style_Attached_Property_Value_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<Style Selector=\"Button\"><Setter Property=\"TextBlock.FontWeight\" Value=\"", "Bo", "Bold");
+        }
+
+        [Fact]
+        public void Style_Property_Value_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<Style Selector=\"Button.my\"><Setter Property=\"HorizontalAlignment\" Value=\"", "Le", "Left");
+        }
+
+        [Fact]
         public void Image_Source_resm_Uris_Should_Be_Completed()
         {
             AssertSingleCompletion("<Image Source=\"", "resm:", "resm:CompletionEngineTests.Test.bmp?assembly=CompletionEngineTests");

--- a/tests/CompletionEngineTests/BasicTests.cs
+++ b/tests/CompletionEngineTests/BasicTests.cs
@@ -117,5 +117,11 @@ namespace CompletionEngineTests
         {
             AssertSingleCompletion("<UserControl Content=\"{Binding Mode=", "One", "OneWay");
         }
+        
+        [Fact]
+        public void Extension_DataType_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<UserControl ", "x:Data", "x:DataType=\"\"");
+        }
     }
 }

--- a/tests/CompletionEngineTests/CompletionEngineTests.csproj
+++ b/tests/CompletionEngineTests/CompletionEngineTests.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
         <PackageReference Include="xunit" Version="2.3.1" />
-        <PackageReference Include="Avalonia" Version="0.9.0" />
+        <PackageReference Include="Avalonia" Version="0.10.0-preview5" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>


### PR DESCRIPTION
Added support for Avalonia 0.10 features:

- `x:DataType`
- `x:CompileBindings`
- Binding.Path completion from last `x:DataType`
- Style `Setter ` completion for Property and Value

with unit tests for all new features