### PR TITLE
Add support for using and static fields in static extension

### DIFF
--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -164,20 +164,25 @@ namespace Avalonia.Ide.CompletionEngine
 
                         foreach (var fieldDef in typeDef.Fields)
                         {
-                            if (fieldDef.IsStatic && fieldDef.IsPublic &&
-                                (fieldDef.IsRoutedEvent
-                                || fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase)))
+                            if (fieldDef.IsStatic && fieldDef.IsPublic)
                             {
-                                var name = fieldDef.Name;
-                                if (fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase))
+                                if ((fieldDef.IsRoutedEvent || fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase)))
                                 {
-                                    name = name.Substring(0, name.Length - "Event".Length);
-                                }
+                                    var name = fieldDef.Name;
+                                    if (fieldDef.Name.EndsWith("Event", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        name = name.Substring(0, name.Length - "Event".Length);
+                                    }
 
-                                type.Events.Add(new MetadataEvent(name,
-                                    types.GetValueOrDefault(fieldDef.ReturnTypeFullName),
-                                    types.GetValueOrDefault(typeDef.FullName),
-                                    true));
+                                    type.Events.Add(new MetadataEvent(name,
+                                        types.GetValueOrDefault(fieldDef.ReturnTypeFullName),
+                                        types.GetValueOrDefault(typeDef.FullName),
+                                        true));
+                                }
+                                else if(type.IsStatic)
+                                {
+                                    type.Properties.Add(new MetadataProperty(fieldDef.Name, null, type, false, true, true, false));
+                                }
                             }
                         }
                     }

--- a/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
+++ b/src/Avalonia.Ide.CompletionEngine/AssemblyMetadata/MetadataConverter.cs
@@ -85,8 +85,18 @@ namespace Avalonia.Ide.CompletionEngine
                     typeDefs[mt] = type;
                     metadata.AddType("clr-namespace:" + type.Namespace + ";assembly=" + asm.Name, mt);
                     string[] nsAliases = null;
-                    if (aliases.TryGetValue(type.Namespace, out nsAliases))
-                        foreach (var alias in nsAliases) metadata.AddType(alias, mt);
+                    string usingNamespace = $"using:{type.Namespace}";
+                    if (!aliases.TryGetValue(type.Namespace, out nsAliases))
+                    {
+                        nsAliases = new string[] { usingNamespace };
+                        aliases[type.Namespace] = nsAliases;
+                    }
+                    else if (!nsAliases.Contains(usingNamespace))
+                    {
+                        aliases[type.Namespace] = nsAliases.Union(new string[] { usingNamespace }).ToArray();
+                    }
+
+                    foreach (var alias in nsAliases) metadata.AddType(alias, mt);
                 }
 
                 ProcessAvaloniaResources(asm, asmTypes, avaresValues);

--- a/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
+++ b/src/Avalonia.Ide.CompletionEngine/CompletionEngine.cs
@@ -322,8 +322,12 @@ namespace Avalonia.Ide.CompletionEngine
                                     .Select(v => new Completion(v.Substring("clr-namespace:".Length), v, v, CompletionKind.Namespace)));
                         else
                         {
+                            if ("using:".StartsWith(state.AttributeValue))
+                                completions.Add(new Completion("using:", CompletionKind.Namespace));
+
                             if ("clr-namespace:".StartsWith(state.AttributeValue))
                                 completions.Add(new Completion("clr-namespace:", CompletionKind.Namespace));
+
                             completions.AddRange(
                                 metadata.Namespaces.Keys.Where(
                                     v =>

--- a/tests/CompletionEngineTests/AdvancedTests.cs
+++ b/tests/CompletionEngineTests/AdvancedTests.cs
@@ -41,6 +41,12 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void Extension_With_CtorArgument_Static_Field_Values_Should_Be_Completed()
+        {
+            AssertSingleCompletion("<UserControl IsEnabled=\"{Binding Converter={x:Static ", "ObjectConverters.IsN", "ObjectConverters.IsNull");
+        }
+
+        [Fact]
         public void Extension_Property_With_WellKnown_Value_Should_Be_Completed()
         {
             AssertSingleCompletion("<UserControl Background=\"{Binding RelativeSource=", "Se", "Self");

--- a/tests/CompletionEngineTests/BasicTests.cs
+++ b/tests/CompletionEngineTests/BasicTests.cs
@@ -101,6 +101,16 @@ namespace CompletionEngineTests
         }
 
         [Fact]
+        public void Using_NameSpaces_Should_Be_Completed()
+        {
+            var compl = GetCompletionsFor("<UserControl xmlns:t=\"using:Ava");
+
+            Assert.NotEmpty(compl.Completions);
+            Assert.Contains(compl.Completions, v => v.InsertText == "using:Avalonia.Data");
+            Assert.Contains(compl.Completions, v => v.InsertText == "using:Avalonia.Controls");
+        }
+
+        [Fact]
         public void Extension_Should_Be_Completed()
         {
             AssertSingleCompletion("<UserControl Content=\"{", "Bind", "Binding");


### PR DESCRIPTION
added support for completion for:

- recently supported using in xmlns example: `xmlns:my="using:Avalonia.Controls"`
- static fields in x:Static example: `Converter="{x:Static ObjectConverters.IsNull}"`

with unit tests