### PR TITLE
feat: Ignore gt symbol after close xml tag

### DIFF
--- a/src/Avalonia.Ide.CompletionEngine/TextManipulator.cs
+++ b/src/Avalonia.Ide.CompletionEngine/TextManipulator.cs
@@ -72,6 +72,15 @@ namespace Avalonia.Ide.CompletionEngine
 
                 new CloseXmlTagManipulation(_state, _text, _position).TryCloseTag(textChange, maniplations);
             }
+            else if(_state.State == XmlParser.ParserState.None && textChange.OldText == string.Empty && textChange.NewText == ">")
+            {
+                var pp = textChange.NewPosition - 2;
+                // if xmltag already closed ingnore '>'
+                if (pp > -1 && _text.Span[pp] == '/' && _text.Span[pp+1]=='>')
+                {
+                    maniplations.Add(TextManipulation.Delete(textChange.NewPosition, 1));
+                }
+            }
 
             return maniplations.OrderByDescending(n => n.Start).ToList();
         }


### PR DESCRIPTION
fixes AvaloniaUI/AvaloniaVS#248

When editing xaml after pressing the '/' character to close the tag and then the '>' character, '>' is ignored.